### PR TITLE
rspec-terraspace dependency added

### DIFF
--- a/terraspace.gemspec
+++ b/terraspace.gemspec
@@ -29,10 +29,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "thor"
   spec.add_dependency "zeitwerk"
 
-  # baseline plugins
+  # core baseline plugins
   spec.add_dependency "terraspace_plugin_aws"
   spec.add_dependency "terraspace_plugin_azurerm"
   spec.add_dependency "terraspace_plugin_google"
+  spec.add_dependency "rspec-terraspace"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

terraspace generators currently dont work without rspec-terraspace dependency. Adding it as a fix for now.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Terraspace project, please provide an example repo.
-->


## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

