### PR TITLE
cloud.relative_root setting

### DIFF
--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -17,8 +17,9 @@ module Terraspace
       config.cloud = ActiveSupport::OrderedOptions.new
       config.cloud.overwrite = true
       config.cloud.overwrite_sensitive = true
+      config.cloud.relative_root = nil
       config.build = ActiveSupport::OrderedOptions.new
-      config.build.cache_root = nil # defaults to .terraspace-cache
+      config.build.cache_root = nil # defaults to /full/path/to/.terraspace-cache
       config.build.cache_dir = ":CACHE_ROOT/:REGION/:ENV/:BUILD_DIR"
       config
     end

--- a/lib/terraspace/terraform/api.rb
+++ b/lib/terraspace/terraform/api.rb
@@ -12,7 +12,6 @@ module Terraspace::Terraform
 
     # Docs: https://www.terraform.io/docs/cloud/api/workspaces.html
     def set_working_dir
-      working_directory = @mod.cache_dir.sub("#{Terraspace.root}/", '')
       return if working_directory == workspace['attributes']['working-directory']
 
       payload = {
@@ -24,6 +23,12 @@ module Terraspace::Terraform
         }
       }
       http.patch("organizations/#{@organization}/workspaces/#{@workspace_name}", payload)
+    end
+
+    def working_directory
+      cache_dir = @mod.cache_dir.sub("#{Terraspace.root}/", '')
+      relative_root = Terraspace.config.cloud.relative_root # prepended to TFC Working Directory
+      relative_root ? "#{relative_root}/#{cache_dir}" : cache_dir
     end
 
     def set_env_vars


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Add `config.cloud.relative_root` setting. This is useful for the VCS-driven workflow and the repo has the terraform project within a subfolder.

## Version Changes

Patch