### PR TITLE
config.clean_cache option

### DIFF
--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -21,6 +21,7 @@ module Terraspace
       config.build = ActiveSupport::OrderedOptions.new
       config.build.cache_root = nil # defaults to /full/path/to/.terraspace-cache
       config.build.cache_dir = ":CACHE_ROOT/:REGION/:ENV/:BUILD_DIR"
+      config.build.clean_cache = nil # defaults to /full/path/to/.terraspace-cache
       config
     end
 

--- a/lib/terraspace/builder.rb
+++ b/lib/terraspace/builder.rb
@@ -3,7 +3,7 @@ module Terraspace
     def run
       Terraspace::CLI::CheckSetup.check!
       @mod.root_module = true
-      Compiler::Cleaner.new(@mod, @options).clean
+      Compiler::Cleaner.new(@mod, @options).clean if clean?
       build_dir = Util.pretty_path(@mod.cache_dir)
       logger.info "Building #{build_dir}"
 
@@ -38,6 +38,11 @@ module Terraspace
 
     def dirs(path)
       Dir.glob("#{Terraspace.root}/#{path}")
+    end
+
+    def clean?
+      clean_cache = Terraspace.config.build.clean_cache
+      clean_cache.nil? ? true : clean_cache
     end
   end
 end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement. 
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

config.build.clean_cache setting option.

Useful if the default clean process doesnt work for special terraspace setups. Maybe with the [VCS-Driven workflow](https://terraspace.cloud/docs/cloud/workflows/vcs/)

## Version Changes

Patch