### PR TITLE
Auto bucket creation

### DIFF
--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -16,6 +16,7 @@ module Terraspace
       config.all.exit_on_fail.down = true
       config.all.exit_on_fail.up = true
       config.all.ignore_stacks = []
+      config.auto_create_backend = true
       config.build = ActiveSupport::OrderedOptions.new
       config.build.cache_dir = ":CACHE_ROOT/:REGION/:ENV/:BUILD_DIR"
       config.build.cache_root = nil # defaults to /full/path/to/.terraspace-cache

--- a/lib/terraspace/builder.rb
+++ b/lib/terraspace/builder.rb
@@ -62,8 +62,9 @@ module Terraspace
     end
 
     def create_backend?
-      ARGV[0] == "up" || # terraspace up
-      ARGV[0] == "all" && ARGV[1] == "up" # terraspace up
+      commands = %w[down init output plan providers refresh show up validate]
+      commands.include?(ARGV[0]) ||                  # IE: terraspace up
+      ARGV[0] == "all" && commands.include?(ARGV[1]) # IE: terraspace all up
     end
 
     def clean

--- a/lib/terraspace/builder.rb
+++ b/lib/terraspace/builder.rb
@@ -57,6 +57,7 @@ module Terraspace
 
     # Auto create after build_unresolved since will need to run state pull for dependencies
     def auto_create_backend
+      return if Terraspace.config.auto_create_backend == false
       return unless create_backend?
       Terraspace::Compiler::Backend.new(@mod).create
     end


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix edge case when bucket does not yet exist and there's a project with dependencies defined. The bucket creation needs to happen also in this case. Create bucket for commands: down init output plan providers refresh show up validate

Also add config.auto_create_backend setting.  User can disable auto creation with 

```ruby
Terraspace.configure do |config|
  # ...
  config.auto_create_backend
end
```

## Version Changes

Patch