### PR TITLE
to_ruby concept and renamed to output helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [0.3.5 UNRELEASED]
+* rename `terraform_output` helper to `output`. Keep `terraform_output` for backwards compatibility
+* output formatters removed in favor for `.to_ruby` method.
+
 ## [0.3.4]
 * #42 update cli docs and bug fixes
 * fix console by using system instead of popen3

--- a/lib/terraspace/all/preview.rb
+++ b/lib/terraspace/all/preview.rb
@@ -22,7 +22,7 @@ module Terraspace::All
       @batches.map do |batch|
         i += 1
         batch.map do |stack|
-          command = "   terraspace #{@command}"
+          command = "    terraspace #{@command}"
           ljust = command.size + max_name_size + 1
           command = "#{command} #{stack.name}"
           command.ljust(ljust, ' ') + " # batch #{i}"

--- a/lib/terraspace/compiler/dependencies/helpers.rb
+++ b/lib/terraspace/compiler/dependencies/helpers.rb
@@ -1,0 +1,34 @@
+module Terraspace::Compiler::Dependencies
+  # This is a separate module specifically because the DSL also has an output method.
+  # The module allows us to include dependency related methods only within tfvars context for the DSL.
+  #
+  #     1. Only include this module to DSL tfvars context.
+  #        So the output method works in tfvars .rb files works.
+  #        At the same time, the DSL usage of output also works for normal main.tf files.
+  #        Passing specs prove this.
+  #     2. For ERB, there's currently only one ERB context. So this module is included in all contexts.
+  #        The builder only processes dependencies from tfvars, so these helpers are only respected there.
+  #
+  # Where the module is included in the code:
+  #
+  #     1. lib/terraspace/compiler/dsl/syntax/tfvar.rb
+  #     2. lib/terraspace/compiler/erb/helpers.rb
+  #
+  module Helpers
+    def output(identifier, options={})
+      Terraspace::Dependency::Helper::Output.new(@mod, identifier, options).result
+    end
+    alias_method :terraform_output, :output # backwards compatibility
+
+    def depends_on(*child_names, **options)
+      child_names.flatten!
+      child_names.map do |child_name|
+        each_depends_on(child_name, options)
+      end.join("\n")
+    end
+
+    def each_depends_on(child_name, options={})
+      Terraspace::Dependency::Helper::DependsOn.new(@mod, child_name, options).result
+    end
+  end
+end

--- a/lib/terraspace/compiler/dsl/syntax/helpers/common.rb
+++ b/lib/terraspace/compiler/dsl/syntax/helpers/common.rb
@@ -1,8 +1,6 @@
 module Terraspace::Compiler::Dsl::Syntax::Helpers
   module Common
     extend Memoist
-    Fetcher = Terraspace::Terraform::RemoteState::Fetcher
-    Marker = Terraspace::Terraform::RemoteState::Marker
     Meta = Terraspace::Compiler::Dsl::Meta
 
     def var
@@ -24,30 +22,6 @@ module Terraspace::Compiler::Dsl::Syntax::Helpers
       args = ARGV[0..1] || []
       command = ["terraspace"] + args
       command.join(separator)
-    end
-
-    def terraform_output(identifier, options={})
-      if @mod.resolved # dependencies have been resolved
-        Fetcher.new(@mod, identifier, options).output
-      else
-        Marker::Output.new(@mod, identifier, options).build
-      end
-    end
-
-    def depends_on(*child_names, **options)
-      child_names.flatten!
-      child_names.map do |child_name|
-        each_depends_on(child_name, options)
-      end.join("\n")
-    end
-
-    def each_depends_on(child_name, options={})
-      if @mod.resolved # dependencies have been resolved
-        # Note: A generated line is not really needed. Dependencies are stored in memory. Added to assist users with debugging
-        "# #{@mod.name} depends on #{child_name}"
-      else
-        Marker::Output.new(@mod, child_name, options).build
-      end
     end
   end
 end

--- a/lib/terraspace/compiler/dsl/syntax/tfvar.rb
+++ b/lib/terraspace/compiler/dsl/syntax/tfvar.rb
@@ -1,5 +1,6 @@
 module Terraspace::Compiler::Dsl::Syntax
   module Tfvar
     include_dir("tfvar")
+    include Terraspace::Compiler::Dependencies::Helpers
   end
 end

--- a/lib/terraspace/compiler/erb/context.rb
+++ b/lib/terraspace/compiler/erb/context.rb
@@ -1,6 +1,6 @@
 module Terraspace::Compiler::Erb
   class Context
-    include Terraspace::Compiler::Dsl::Syntax::Mod
+    include Helpers
 
     attr_reader :mod, :options
     def initialize(mod)

--- a/lib/terraspace/compiler/erb/helpers.rb
+++ b/lib/terraspace/compiler/erb/helpers.rb
@@ -1,0 +1,6 @@
+module Terraspace::Compiler::Erb
+  module Helpers
+    include Terraspace::Compiler::Dsl::Syntax::Mod
+    include Terraspace::Compiler::Dependencies::Helpers
+  end
+end

--- a/lib/terraspace/dependency/helper/base.rb
+++ b/lib/terraspace/dependency/helper/base.rb
@@ -1,0 +1,7 @@
+module Terraspace::Dependency::Helper
+  class Base
+    def initialize(mod, identifier, options)
+      @mod, @identifier, @options = mod, identifier, options
+    end
+  end
+end

--- a/lib/terraspace/dependency/helper/depends_on.rb
+++ b/lib/terraspace/dependency/helper/depends_on.rb
@@ -1,0 +1,12 @@
+module Terraspace::Dependency::Helper
+  class DependsOn < Base
+    def result
+      if @mod.resolved # dependencies have been resolved
+        # Note: A generated line is not really needed. Dependencies are stored in memory. Added to assist users with debugging
+        "# #{@mod.name} depends on #{@identifier}" # raw String value
+      else
+        Terraspace::Terraform::RemoteState::Marker::Output.new(@mod, @identifier, @options).build # Returns OutputProxy which defaults to json
+      end
+    end
+  end
+end

--- a/lib/terraspace/dependency/helper/output.rb
+++ b/lib/terraspace/dependency/helper/output.rb
@@ -1,0 +1,11 @@
+module Terraspace::Dependency::Helper
+  class Output < Base
+    def result
+      if @mod.resolved # dependencies have been resolved
+        Terraspace::Terraform::RemoteState::Fetcher.new(@mod, @identifier, @options).output # Returns OutputProxy which defaults to json
+      else
+        Terraspace::Terraform::RemoteState::Marker::Output.new(@mod, @identifier, @options).build # Returns OutputProxy is NullObject when unresolved
+      end
+    end
+  end
+end

--- a/lib/terraspace/terraform/remote_state/marker/output.rb
+++ b/lib/terraspace/terraform/remote_state/marker/output.rb
@@ -8,6 +8,7 @@ module Terraspace::Terraform::RemoteState::Marker
       @child_name, @output_key = @identifier.split('.')
     end
 
+    # Returns OutputProxy
     def build
       if valid?
         Terraspace::Dependency::Registry.register(@parent_name, @child_name)
@@ -16,7 +17,7 @@ module Terraspace::Terraform::RemoteState::Marker
       end
       # MARKER for debugging. Only appears on 1st pass. Will not see unless changing Terraspace code for debugging.
       marker = "MARKER:terraform_output('#{@identifier}')"
-      Terraspace::Terraform::RemoteState::OutputProxy.new(marker, @options)
+      Terraspace::Terraform::RemoteState::OutputProxy.new(@mod, marker, @options)
     end
 
     def valid?
@@ -26,6 +27,7 @@ module Terraspace::Terraform::RemoteState::Marker
     def warning
       logger.warn "WARN: The #{@child_name} stack does not exist".color(:yellow)
       caller_line = caller.find { |l| l.include?('.tfvars') }
+      return unless caller_line # specs dont have a tfvars file
       source_code = PrettyTracer.new(caller_line).source_code
       logger.info source_code
     end

--- a/lib/terraspace/terraform/remote_state/null_object.rb
+++ b/lib/terraspace/terraform/remote_state/null_object.rb
@@ -1,0 +1,40 @@
+module Terraspace::Terraform::RemoteState
+  class NullObject
+    def to_a
+      []
+    end
+
+    def to_ary
+      []
+    end
+
+    def to_s
+      "(unresolved)" # always returned as part of first unresolved processing pass
+    end
+    alias_method :to_str, :to_s # ERB requires to_str
+
+    def to_f
+      0.0
+    end
+
+    def to_i
+      0
+    end
+
+    def nil?
+      true
+    end
+
+    def inspect
+      format("#<%s:0x%x>", self.class, object_id)
+    end
+
+    def method_missing(*_args, &_block)
+      self
+    end
+
+    def respond_to?(_message, _include_private = false)
+      true
+    end
+  end
+end

--- a/spec/fixtures/dependencies/app/stacks/a1/tfvars/dev.tfvars
+++ b/spec/fixtures/dependencies/app/stacks/a1/tfvars/dev.tfvars
@@ -1,0 +1,1 @@
+length = <%= output('b1.length') %>

--- a/spec/fixtures/fetcher/c1.json
+++ b/spec/fixtures/fetcher/c1.json
@@ -8,6 +8,10 @@
       "value": 1,
       "type": "number"
     },
+    "complex": {
+      "value": ["a","b"],
+      "type": "list"
+    },
     "random_pet_id": {
       "value": "valued-buzzard",
       "type": "string"

--- a/spec/terraspace/compiler/erb/render_spec.rb
+++ b/spec/terraspace/compiler/erb/render_spec.rb
@@ -1,0 +1,15 @@
+describe Terraspace::Compiler::Erb::Render do
+  let(:render) { described_class.new(mod, src_path) }
+  let(:mod)    { Terraspace::Mod.new("a1") }
+
+  # Only testing mod unresolved as a sanity check and its worth the ROI.
+  # The resolved would the Fetcher. We have unit tests to cover those other changes.
+  context "a1" do
+    let(:src_path) { fixture("dependencies/app/stacks/a1/tfvars/dev.tfvars") }
+    it "build" do
+      allow(Terraspace::Terraform::RemoteState::Marker::Output).to receive(:stack_names).and_return("b1")
+      result = render.build
+      expect(result).to eq "length = (unresolved)"
+    end
+  end
+end

--- a/spec/terraspace/dependency/helper/depends_on_spec.rb
+++ b/spec/terraspace/dependency/helper/depends_on_spec.rb
@@ -1,0 +1,27 @@
+describe Terraspace::Dependency::Helper::DependsOn do
+  let(:depends_on) do
+    described_class.new(mod, identifier, options)
+  end
+  let (:mod) { Terraspace::Mod.new("a1") }
+  # follow args dont matter for spec
+  let (:identifier) { "b1" }
+  let (:options) { {} }
+
+  context "unresolved" do
+    before(:each) { mod.resolved = false }
+    it "result calls Marker::Output" do
+      allow(Terraspace::Terraform::RemoteState::Marker::Output).to receive(:new).and_return(double(:marker_output).as_null_object)
+      result = depends_on.result
+      expect(result).to be_a(RSpec::Mocks::Double)
+      expect(result.instance_variable_get(:@name)).to eq :marker_output
+    end
+  end
+
+  context "resolved" do
+    before(:each) { mod.resolved = true }
+    it "return an raw String" do
+      result = depends_on.result
+      expect(result).to eq "# a1 depends on b1"
+    end
+  end
+end

--- a/spec/terraspace/dependency/helper/output_spec.rb
+++ b/spec/terraspace/dependency/helper/output_spec.rb
@@ -1,0 +1,29 @@
+describe Terraspace::Dependency::Helper::Output do
+  let(:output) do
+    described_class.new(mod, identifier, options)
+  end
+  let (:mod) { Terraspace::Mod.new("foo") }
+  # doesnt matter for spec
+  let (:identifier) { nil }
+  let (:options) { nil }
+
+  context "unresolved" do
+    before(:each) { mod.resolved = false }
+    it "result calls Marker::Output" do
+      allow(Terraspace::Terraform::RemoteState::Marker::Output).to receive(:new).and_return(double(:marker_output).as_null_object)
+      result = output.result
+      expect(result).to be_a(RSpec::Mocks::Double)
+      expect(result.instance_variable_get(:@name)).to eq :marker_output
+    end
+  end
+
+  context "resolved" do
+    before(:each) { mod.resolved = true }
+    it "result calls Fetcher" do
+      allow(Terraspace::Terraform::RemoteState::Fetcher).to receive(:new).and_return(double(:fetcher_output).as_null_object)
+      result = output.result
+      expect(result).to be_a(RSpec::Mocks::Double)
+      expect(result.instance_variable_get(:@name)).to eq :fetcher_output
+    end
+  end
+end

--- a/spec/terraspace/terraform/remote_state/fetcher_spec.rb
+++ b/spec/terraspace/terraform/remote_state/fetcher_spec.rb
@@ -11,41 +11,122 @@ describe Terraspace::Terraform::RemoteState::Fetcher do
     double("c1").as_null_object
   end
 
-  context "pull success" do
-    let(:state_path)   { "spec/fixtures/fetcher/c1.json" }
-    let(:pull_success) { true }
+  context "to_s uses to_json by default" do
+    context "pull success" do
+      let(:state_path)   { "spec/fixtures/fetcher/c1.json" }
+      let(:pull_success) { true }
 
-    context "c1.length" do
-      let(:identifier) { "c1.length" }
-      it "fetched found attribute" do
-        expect(fetcher.output.raw).to eq 1 # matches spec/fixtures/fetcher/c1.json outputs.length.value
+      context "c1.length" do
+        let(:identifier) { "c1.length" }
+        it "fetched found attribute" do
+          expect(fetcher.output.to_s).to eq '1' # Integer as json matches spec/fixtures/fetcher/c1.json outputs.length.value
+        end
+      end
+
+      context "c1.complex" do
+        let(:identifier) { "c1.complex" }
+        it "fetched found attribute" do
+          expect(fetcher.output.to_s).to eq ["a","b"].to_json # matches spec/fixtures/fetcher/c1.json outputs.complex.value
+        end
+      end
+
+      context "c1.does-not-exist" do
+        let(:identifier) { "c1.does-not-exist" }
+        it "fetched missing output" do
+          output_proxy = fetcher.output
+          expect(output_proxy.raw).to be nil
+          value = output_proxy.to_s
+          # (Output length9 was not found for the b1 tfvars file. Either c1 stack has not been deployed yet or it does not have this output: length9)
+          expect(value).to include "not found"
+        end
       end
     end
 
-    context "c1.does-not-exist" do
-      let(:identifier) { "c1.does-not-exist" }
-      it "fetched missing output" do
-        output_proxy = fetcher.output
-        expect(output_proxy.raw).to be nil
-        # (Output length9 was not found for the b1 tfvars file. Either c1 stack has not been deployed yet or it does not have this output: length9)
-        error = output_proxy.options[:error]
-        expect(error).to include "not found"
+    context "pull fail" do
+      let(:state_path)   { nil }
+      let(:pull_success) { false }
+
+      context "stack needs to be deployed" do
+        let(:identifier) { "c1.length" }
+        it "fetched" do
+          output_proxy = fetcher.output
+          expect(output_proxy.raw).to be nil
+          # (Output length could not be looked up for the b1 tfvars file. c1 stack needs to be deployed)
+          value = output_proxy.to_s
+          expect(value).to include "stack needs to be deployed"
+        end
+      end
+
+      context "bucket does not exist" do
+        let(:identifier) { "c1.length" }
+        it "fetched" do
+          fetcher.bucket_not_found_error # fake it!
+          output_proxy = fetcher.output
+          expect(output_proxy.raw).to be nil
+          # (Output length could not be looked up for the b1 tfvars file. c1 stack needs to be deployed)
+          value = output_proxy.to_s
+          expect(value).to include "bucket for the backend could not be found"
+        end
       end
     end
   end
 
-  context "pull fail" do
-    let(:state_path)   { nil }
-    let(:pull_success) { false }
+  context "to_ruby" do
+    context "pull success" do
+      let(:state_path)   { "spec/fixtures/fetcher/c1.json" }
+      let(:pull_success) { true }
 
-    context "c1.length" do
-      let(:identifier) { "c1.length" }
-      it "fetched" do
-        output_proxy = fetcher.output
-        expect(output_proxy.raw).to be nil
-        # (Output length could not be looked up for the b1 tfvars file. c1 stack needs to be deployed)
-        error = output_proxy.options[:error]
-        expect(error).to include "stack needs to be deployed"
+      context "c1.length" do
+        let(:identifier) { "c1.length" }
+        it "fetched found attribute" do
+          expect(fetcher.output.to_ruby).to eq 1 # raw Integer
+        end
+      end
+
+      context "c1.complex" do
+        let(:identifier) { "c1.complex" }
+        it "fetched found attribute" do
+          expect(fetcher.output.to_ruby).to eq ["a","b"] # raw Array
+        end
+      end
+
+      context "c1.does-not-exist" do
+        let(:identifier) { "c1.does-not-exist" }
+        it "fetched missing output" do
+          output_proxy = fetcher.output
+          expect(output_proxy.raw).to be nil
+          value = output_proxy.to_ruby
+          # (Output length9 was not found for the b1 tfvars file. Either c1 stack has not been deployed yet or it does not have this output: length9)
+          expect(value).to include "not found"
+        end
+      end
+    end
+
+    context "pull fail" do
+      let(:state_path)   { nil }
+      let(:pull_success) { false }
+
+      context "stack needs to be deployed" do
+        let(:identifier) { "c1.length" }
+        it "fetched" do
+          output_proxy = fetcher.output
+          expect(output_proxy.raw).to be nil
+          # (Output length could not be looked up for the b1 tfvars file. c1 stack needs to be deployed)
+          value = output_proxy.to_s
+          expect(value).to include "stack needs to be deployed"
+        end
+      end
+
+      context "bucket does not exist" do
+        let(:identifier) { "c1.length" }
+        it "fetched" do
+          fetcher.bucket_not_found_error # fake it!
+          output_proxy = fetcher.output
+          expect(output_proxy.raw).to be nil
+          # (Output length could not be looked up for the b1 tfvars file. c1 stack needs to be deployed)
+          value = output_proxy.to_s
+          expect(value).to include "bucket for the backend could not be found"
+        end
       end
     end
   end

--- a/spec/terraspace/terraform/remote_state/marker/output_spec.rb
+++ b/spec/terraspace/terraform/remote_state/marker/output_spec.rb
@@ -1,0 +1,36 @@
+describe Terraspace::Terraform::RemoteState::Marker::Output do
+  let(:output) do
+    output = described_class.new(mod, identifier, options)
+    allow(output).to receive(:warning) # supress warning messaging about missing child stack
+    output
+  end
+  let (:mod)        { Terraspace::Mod.new("a1") }
+  let (:options)    { {} }
+
+  before(:each) do
+    Terraspace::Dependency::Registry.class_variable_set("@@data", Set.new)
+  end
+
+  # markers are always only called during unresolved stage
+  context "child stack found" do
+    let(:identifier) { "b1.length" }
+    it "registers dependency and always return a OutputProxy" do
+      allow(output).to receive(:valid?).and_return(true) # child stack found
+      result = output.build
+      expect(result).to be_a(Terraspace::Terraform::RemoteState::OutputProxy)
+      set = Terraspace::Dependency::Registry.data
+      expect(set).not_to be_empty
+    end
+  end
+
+  context "child stack not found" do
+    let(:identifier) { "b1.length" }
+    it "does not registers dependency and always return a OutputProxy" do
+      allow(output).to receive(:valid?).and_return(false) # child stack not found
+      result = output.build
+      expect(result).to be_a(Terraspace::Terraform::RemoteState::OutputProxy)
+      set = Terraspace::Dependency::Registry.data
+      expect(set).to be_empty
+    end
+  end
+end

--- a/spec/terraspace/terraform/remote_state/output_proxy_spec.rb
+++ b/spec/terraspace/terraform/remote_state/output_proxy_spec.rb
@@ -1,0 +1,69 @@
+NullObject = Terraspace::Terraform::RemoteState::NullObject
+
+describe Terraspace::Terraform::RemoteState::OutputProxy do
+  let(:proxy) do
+    described_class.new(mod, raw, options)
+  end
+  let (:mod) { Terraspace::Mod.new("foo") }
+  let (:raw) { nil }
+  let (:options) { {} }
+
+  context "unresolved" do
+    before(:each) { mod.resolved = false }
+    it "always return NullObject" do
+      value = proxy.to_s
+      expect(value).to be_a(NullObject)
+      expect(value.to_str).to eq "(unresolved)"
+    end
+  end
+
+  # Resolved value should always return a String because ERB requires string.
+  # Always use to_json.
+  context "resolved with mock" do
+    before(:each) { mod.resolved = true }
+    let (:raw) { nil }
+    let (:options) { {mock: "mock value"} }
+
+    it "return to_json String with mock value" do
+      value = proxy.to_s
+      expect(value).to be_a(String)
+      expect(value.to_str).to eq '"mock value"' # note double quotes from the to_json
+    end
+  end
+
+  context "resolved with errors" do
+    before(:each) { mod.resolved = true }
+    let (:raw) { nil }
+    let (:options) { {error: "error message"} }
+
+    it "return to_json String with error message" do
+      value = proxy.to_s
+      expect(value).to be_a(String)
+      expect(value.to_str).to eq '"error message"' # note double quotes from the to_json
+    end
+  end
+
+  context "to_ruby resolved with mock" do
+    before(:each) { mod.resolved = true }
+    let (:raw) { nil }
+    let (:options) { {mock: "mock value"} }
+
+    it "return to_json String with mock value" do
+      value = proxy.to_ruby
+      expect(value).to be_a(String)
+      expect(value.to_str).to eq "mock value"
+    end
+  end
+
+  context "to_ruby resolved with errors" do
+    before(:each) { mod.resolved = true }
+    let (:raw) { nil }
+    let (:options) { {error: "error message"} }
+
+    it "return to_json String with error message" do
+      value = proxy.to_ruby
+      expect(value).to be_a(String)
+      expect(value.to_str).to eq "error message"
+    end
+  end
+end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* to_ruby natural interface to access output with full power of Ruby
* to_json by default. can access ruby format with to_ruby
* remove formatters concept
* in unresolved pass, NullObjects are returned, makes to_ruby possible
* in resolved pass, raw values are returned
* only include output helper in tfvar evaluation context for DSL
* this avoids collision with the output DSL method for main.tf
* improve specs for tfvars and dependencies

## Context

Wanted a better way to access the output data with the full power of Ruby.

## How to Test

* Run specs
* Deploy [terraspace-graph-demo](https://github.com/boltops-tools/terraspace-graph-demo): For regression
* Try complex type example from docs

## Version Changes

Patch