### PR TITLE
improve logs management commands

### DIFF
--- a/lib/terraspace/cli/logs.rb
+++ b/lib/terraspace/cli/logs.rb
@@ -1,5 +1,7 @@
 class Terraspace::CLI
   class Logs < Terraspace::Command
+    class_option :yes, aliases: :y, type: :boolean, desc: "bypass are you sure prompt"
+
     desc "truncate", "Truncates logs. IE: Keeps the files but removes contents and zero bytes the files."
     long_desc Help.text("logs/truncate")
     def truncate

--- a/lib/terraspace/cli/logs/tasks.rb
+++ b/lib/terraspace/cli/logs/tasks.rb
@@ -1,17 +1,21 @@
 class Terraspace::CLI::Logs
   class Tasks
+    include Terraspace::Util::Sure
+
     def initialize(options={})
       @options = options
+      Terraspace.check_project!
     end
 
     def truncate
-      puts "Truncating log files in #{pretty_log_root}/" unless @options[:mute]
+      are_you_sure?("truncate")
       log_files.each do |path|
         File.open(path, "w").close # truncates files
       end
     end
 
     def remove
+      are_you_sure?("remove")
       puts "Removing all files in #{pretty_log_root}/" unless @options[:mute]
       FileUtils.rm_rf(log_root)
       FileUtils.mkdir_p(log_root)
@@ -27,6 +31,14 @@ class Terraspace::CLI::Logs
 
     def log_root
       Terraspace.config.log.root
+    end
+
+    def are_you_sure?(action)
+      message = <<~EOL.chomp
+        Will #{action} all the log files in #{pretty_log_root}/ folder
+        Are you sure?
+      EOL
+      sure?(message) # from Util::Sure
     end
   end
 end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* prompt user before removing or truncating logs. allow user to bypass with `-y` option
* check if within Terraspace project folder

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

Run commands:

    terraspace logs remove
    terraspace logs truncate
    terraspace logs remove -y
    terraspace logs truncate -y

## Version Changes

Patch