### PR TITLE
Logs pid input

### DIFF
--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -110,6 +110,7 @@ module Terraspace
     option :follow, aliases: %w[f], type: :boolean, desc: "Follow the log in live tail fashion. Must specify a stack if using this option."
     option :limit, aliases: %w[n], default: 10, type: :numeric, desc: "Number of lines to limit showing. Only applies in no-follow mode."
     option :all, aliases: %w[a], type: :boolean, desc: "All mode turns off the limit. Defaults to all if a single log is specified. Only applies in no-follow mode."
+    option :pid, aliases: %w[p], desc: "Filter by pid. Defaults to the last pid at the bottom of the log file."
     def logs(action=nil, stack=nil)
       Logs.new(@options.merge(action: action, stack: stack)).run
     end

--- a/lib/terraspace/cli/help/logs.md
+++ b/lib/terraspace/cli/help/logs.md
@@ -12,12 +12,12 @@ Note, Terraspace automatically checks every second for new logs and adds them to
 
 View last 10 lines of each log file.
 
-    terraspace logs up network # view up log on specific stack
+    terraspace logs up network # view up log on a specific stack
     terraspace logs up         # view all up logs
     terraspace logs down       # view all down logs
     terraspace logs            # view all logs: up, down, etc
 
-By default, the log command shows the last 10 lines of the logs for each log file. You can use the `-n` option to adjust this.
+By default, the logs command shows the last 10 lines for each log file. You can use the `-n` option to adjust this.
 
     terraspace logs -n 2       # view last 2 lines of all logs: up, down, etc
 
@@ -31,14 +31,14 @@ Note, if both an action and stack is specified, then it defaults to showing all 
 
 To tail logs, use the `-f` option.
 
-    terraspace logs up network -f # view up log on specific stack
+    terraspace logs up network -f # view up log on a specific stack
     terraspace logs up -f         # view all up logs
     terraspace logs down -f       # view all down logs
     terraspace logs -f            # view all logs: up, down, etc
 
 ## Timestamps
 
-The timestamps are shown by default when you are looking for multiple files.  When you specify both the action and stack for a single log file, then timestamps are not shown.
+The timestamps are shown by default when you are looking for multiple files.  When you specify both the action and stack for a single log file, the timestamps are not shown.
 
     terraspace logs up         # timestamps will be shown in this case
     terraspace logs up network # timestamps not be shown in this case

--- a/lib/terraspace/cli/logs/concern.rb
+++ b/lib/terraspace/cli/logs/concern.rb
@@ -17,6 +17,7 @@ class Terraspace::CLI::Logs
 
     # [2020-09-06T21:58:25 #11313 terraspace up b1]:
     def pid(line)
+      return @options[:pid] if @options && @options[:pid] # Terraspace::All::Summary: doesnt have @options set
       md = line.match(/:\d{2} #(\d+) /)
       md[1] if md
     end

--- a/lib/terraspace/terraform/args/default.rb
+++ b/lib/terraspace/terraform/args/default.rb
@@ -26,7 +26,7 @@ module Terraspace::Terraform::Args
         args << var_files.map { |f| "-var-file #{Dir.pwd}/#{f}" }.join(' ')
       end
 
-      args << input_option if input_option
+      args << input_option
 
       # must be at the end
       plan = @options[:plan]
@@ -45,27 +45,17 @@ module Terraspace::Terraform::Args
     end
 
     def input_option
-      option = nil
-      if @options[:auto] && @options[:input].nil?
-        option = " -input=false"
-      end
-      unless @options[:input].nil?
-        input = @options[:input] ? "true" : "false"
-        option = " -input=#{input}" # = sign required for apply when there's a plan at the end. so input=false works input false doesnt
-      end
-      option
+      option = if @options[:auto]
+                 "false"
+               else
+                 @options[:input] ? @options[:input] : "false"
+               end
+      " -input=#{option}"
     end
 
     def init_args
       args = "-get"
-      if @options[:auto] && @options[:input].nil?
-        args << " -input=false"
-      end
-      unless @options[:input].nil?
-        input = @options[:input] ? "true" : "false"
-        args << " -input=#{input}"
-      end
-
+      args << input_option
       args << " -reconfigure" if @options[:reconfigure]
 
       # must be at the end
@@ -86,7 +76,7 @@ module Terraspace::Terraform::Args
 
     def plan_args
       args = []
-      args << input_option if input_option
+      args << input_option
       args << "-destroy" if @options[:destroy]
       args << "-out #{expanded_out}" if @options[:out]
       args

--- a/lib/terraspace/terraform/runner.rb
+++ b/lib/terraspace/terraform/runner.rb
@@ -21,7 +21,7 @@ module Terraspace::Terraform
       current_dir_message # only show once
 
       params = args.flatten.join(' ')
-      command = "terraform #{name} #{params}"
+      command = "terraform #{name} #{params}".squish
       run_hooks("terraform.rb", name) do
         Terraspace::Shell.new(@mod, command, @options.merge(env: custom.env_vars)).run
       end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* Add `--pid` option for `terraspace logs` command. 
* Default to terraform `-input false` behavior.

## Version Changes

Patch