### PR TITLE
retry logic for shared cache error

### DIFF
--- a/lib/terraspace.rb
+++ b/lib/terraspace.rb
@@ -26,8 +26,10 @@ DslEvaluator.backtrace_reject = "lib/terraspace"
 module Terraspace
   extend Core # for Terraspace.root
   class Error < StandardError; end
-  class InitRequiredError < Error; end
+
   class BucketNotFoundError < Error; end
+  class InitRequiredError < Error; end
+  class SharedCacheError < Error; end
 end
 
 Terraspace::Booter.boot

--- a/lib/terraspace/shell.rb
+++ b/lib/terraspace/shell.rb
@@ -6,8 +6,6 @@ module Terraspace
 
     def initialize(mod, command, options={})
       @mod, @command, @options = mod, command, options
-      # error_messages holds aggregation of all error lines
-      @known_error, @error_messages = nil, ''
     end
 
     # requires @mod to be set
@@ -33,9 +31,9 @@ module Terraspace
       Open3.popen3(env, @command, chdir: @mod.cache_dir) do |stdin, stdout, stderr, wait_thread|
         mimic_terraform_input(stdin, stdout)
         while err = stderr.gets
-          @error_messages << err # aggregate all error lines
-          @known_error ||= known_error_type(err)
-          unless @known_error
+          @error ||= Error.new
+          @error.lines << err # aggregate all error lines
+          unless @error.known?
             # Sometimes may print a "\e[31m\n" which like during dependencies fetcher init
             # suppress it so dont get a bunch of annoying "newlines"
             next if err == "\e[31m\n" && @options[:suppress_error_color]
@@ -48,38 +46,12 @@ module Terraspace
       end
     end
 
-    def known_error_type(err)
-      if reinit_required?(err)
-        :reinit_required
-      elsif bucket_not_found?(err)
-        :bucket_not_found
-      end
-    end
-
-    def bucket_not_found?(err)
-      # Message is included in aws, azurerm, and google. See: https://bit.ly/3iOKDri
-      err.include?("Failed to get existing workspaces")
-    end
-
-    def reinit_required?(err)
-      # Example error: https://gist.github.com/tongueroo/f7e0a44b64f0a2e533089b18f331c21e
-      squeezed = @error_messages.gsub("\n", ' ').squeeze(' ') # remove double whitespaces and newlines
-      general_check = squeezed.include?("terraform init") && squeezed.include?("Error:")
-
-      general_check ||
-      err.include?("reinitialization required") ||
-      err.include?("terraform init") ||
-      err.include?("require reinitialization")
-    end
-
     def exit_status(status)
       return if status == 0
 
       exit_on_fail = @options[:exit_on_fail].nil? ? true : @options[:exit_on_fail]
-      if @known_error == :reinit_required
-        raise InitRequiredError.new(@error_messages)
-      elsif @known_error == :bucket_not_found
-        raise BucketNotFoundError.new(@error_messages)
+      if @error && @error.known?
+        raise @error.instance
       elsif exit_on_fail
         logger.error "Error running command: #{@command}".color(:red)
         exit status

--- a/lib/terraspace/shell/error.rb
+++ b/lib/terraspace/shell/error.rb
@@ -1,0 +1,46 @@
+class Terraspace::Shell
+  class Error
+    attr_accessor :lines
+    def initialize
+      @lines = '' # holds aggregation of all error lines
+    end
+
+    def known?
+      !!instance
+    end
+
+    def instance
+      if reinit_required?
+        Terraspace::InitRequiredError.new(@lines)
+      elsif bucket_not_found?
+        Terraspace::BucketNotFound.new(@lines)
+      elsif shared_cache_error?
+        Terraspace::SharedCacheError.new(@lines)
+      end
+    end
+
+    def bucket_not_found?
+      # Message is included in aws, azurerm, and google. See: https://bit.ly/3iOKDri
+      message.include?("Failed to get existing workspaces")
+    end
+
+    def reinit_required?
+      # Example error: https://gist.github.com/tongueroo/f7e0a44b64f0a2e533089b18f331c21e
+      general_check = message.include?("terraform init") && message.include?("Error:")
+      general_check ||
+      message.include?("reinitialization required") ||
+      message.include?("terraform init") ||
+      message.include?("require reinitialization")
+    end
+
+    def message
+      @lines.gsub("\n", ' ').squeeze(' ') # remove double whitespaces and newlines
+    end
+
+    def shared_cache_error?
+      # Example: https://gist.github.com/tongueroo/4f2c925709d21f5810229ce9ca482560
+      message.include?("Failed to install provider from shared cache") ||
+      message.include?("Failed to validate installed provider")
+    end
+  end
+end

--- a/lib/terraspace/terraform/runner/retryer.rb
+++ b/lib/terraspace/terraform/runner/retryer.rb
@@ -1,0 +1,65 @@
+class Terraspace::Terraform::Runner
+  class Retryer
+    include Terraspace::Util::Logging
+    include Terraspace::Util::Pretty
+
+    def initialize(mod, options, command_name, exception)
+      @mod, @options, @command_name, @exception = mod, options, command_name, exception
+      @retries = 1
+    end
+
+    def retry?
+      if @retries <= 3
+        true # will retry
+      else
+        logger.info "ERROR: #{@exception.message}"
+        false # will not retry
+      end
+    end
+
+    def run
+      backoff = 2 ** @retries # 2, 4, 8
+      logger.debug "Waiting #{backoff}s before retrying"
+      sleep(backoff)
+      @retries += 1
+
+      case @exception
+      when Terraspace::SharedCacheError
+        shared_cache_error
+      when Terraspace::InitRequiredError
+        init_required_error
+      end
+    end
+
+    def shared_cache_error
+      logger.info "Terraform Shared Cache error detected. Will purge caches and run `terraform init` to try again."
+      logger.debug "Retry attempt: #{@retries}"
+      logger.debug "#{@exception.class}"
+      logger.debug "#{@exception.message}"
+      purge_caches # Purging the cache "fixes" this terraform bug
+      reinit
+    end
+
+    def init_required_error
+      logger.info "Terraform reinitialization required detected. Will run `terraform init` and try again."
+      logger.debug "Retry attempt: #{@retries}"
+      logger.debug "#{@exception.class}"
+      reinit
+    end
+
+    def reinit
+      Terraspace::Terraform::Runner.new("init", @options).run unless @command_name == "init"
+    end
+
+    def purge_caches
+      dir = "#{@mod.cache_dir}/.terraform"
+      logger.info "Purging #{pretty_path(dir)}"
+      FileUtils.rm_rf(dir)
+
+      dir = "#{Terraspace.config.terraform.plugin_cache.dir}"
+      logger.info "Purging #{pretty_path(dir)}"
+      FileUtils.rm_rf(dir)
+      FileUtils.mkdir_p(dir) # need /tmp/terraspace/plugin_cache dir to exist
+    end
+  end
+end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Pretty super edge case. When terraform plugin cache mismatches from a `.terraform` cache. Example of this error:

> Error while importing hashicorp/random v3.0.0 from the shared cache directory:
after linking registry.terraform.io/hashicorp/random from provider cache at
/tmp/terraspace/plugin_cache it is still not detected in the target directory;
this is a bug in Terraform.

Seems like switching cloud providers will cause this. Also, deleting a plugin binary in the plugin cache is a manual way to reproduce the issue.

To fix the issue, the user will have to remove the `.terraform` cache and plugin cache. This change automates that process.

## How to Test

    # find the aws provider and delete it from the plugin cache
    rm -f /tmp/terraspace/plugin_cache/registry.terraform.io/hashicorp/aws/3.12.0/linux_amd64/terraform-provider-aws_v3.12.0_x5
    terraspace up demo

## Version Changes

Patch