### PR TITLE
fix cloud sync: call build first

### DIFF
--- a/lib/terraspace/cli/cloud.rb
+++ b/lib/terraspace/cli/cloud.rb
@@ -16,6 +16,7 @@ class Terraspace::CLI
 
     desc "destroy STACK", "Destroy workspace by specifying the stack"
     long_desc Help.text("cloud:destroy")
+    yes_option.call
     def destroy(mod)
       Workspace.new(options.merge(mod: mod)).destroy
     end
@@ -24,6 +25,7 @@ class Terraspace::CLI
     long_desc Help.text("cloud:sync")
     yes_option.call
     def sync(*stacks)
+      Terraspace::CLI::Build::Placeholder.new(options).build
       Syncer.new(options.merge(stacks: stacks, override_auto_sync: true)).run
     end
 


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix `terraspace cloud sync` when terraspace project has never been built. Always build before a sync.

## Version Changes

Patch