### PR TITLE
allow envs and regions check feature

### DIFF
--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -18,6 +18,9 @@ module Terraspace
       config.all.exit_on_fail.down = true
       config.all.exit_on_fail.up = true
       config.all.ignore_stacks = []
+      config.allow = ActiveSupport::OrderedOptions.new
+      config.allow.envs = nil
+      config.allow.regions = nil
       config.auto_create_backend = true
       config.build = ActiveSupport::OrderedOptions.new
       config.build.cache_dir = ":CACHE_ROOT/:REGION/:ENV/:BUILD_DIR"

--- a/lib/terraspace/builder.rb
+++ b/lib/terraspace/builder.rb
@@ -18,6 +18,7 @@ module Terraspace
       batches = nil
       FileUtils.mkdir_p(@mod.cache_dir) # so terraspace before build hooks work
       run_hooks("terraspace.rb", "build") do
+        check_allow!
         build_unresolved
         auto_create_backend
         batches = build_batches
@@ -25,6 +26,10 @@ module Terraspace
         logger.info "Built in #{build_dir}" unless @options[:quiet] # from terraspace all
       end
       batches
+    end
+
+    def check_allow!
+      Allow.new(@mod).check!
     end
 
     # Builds dependency graph and returns the batches to run

--- a/lib/terraspace/builder/allow.rb
+++ b/lib/terraspace/builder/allow.rb
@@ -1,0 +1,43 @@
+class Terraspace::Builder
+  class Allow
+    def initialize(mod)
+      @mod = mod
+    end
+
+    def check!
+      messages = []
+      unless env_allowed?
+        messages << "This env is not allowed to be used: TS_ENV=#{Terraspace.env}"
+        messages << "Allowed envs: #{config.allow.envs.join(', ')}"
+      end
+      unless region_allowed?
+        messages << "This region is not allowed to be used: Detected current region=#{current_region}"
+        messages << "Allowed regions: #{config.allow.regions.join(', ')}"
+      end
+      unless messages.empty?
+        puts "ERROR: The configs do not allow this.".color(:red)
+        puts messages
+        exit 1
+      end
+    end
+
+    def env_allowed?
+      return true unless config.allow.envs
+      config.allow.envs.include?(Terraspace.env)
+    end
+
+    def region_allowed?
+      return true unless config.allow.regions
+      config.allow.regions.include?(current_region)
+    end
+
+    def current_region
+      expander = Terraspace::Compiler::Expander.autodetect(@mod).expander
+      expander.region
+    end
+
+    def config
+      Terraspace.config
+    end
+  end
+end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

By default, Terraspace allows deploying to any env and region. This adds a config option that can be used to allow only specific envs and regions. This provides an easy way to configure some safeguards. Example:

config/app.rb

```ruby
Terraspace.configure do |config|
  # ...
  config.allow.envs = %w[dev prod]
  config.allow.regions = %w[us-east-1 us-west-2]
end
```

    $ TS_ENV=foo terraspace up demo
    Building .terraspace-cache/us-west-2/foo/stacks/demo
    ERROR: The configs do not allow this.
    This env is not allowed to be used: TS_ENV=foo
    Allowed envs: dev, prod
    $
    
Note, this can also be achieved with a Terraspace build before hook: https://terraspace.cloud/docs/config/hooks/terraspace/ , but this is a nice convenience for users.

## Context

This was a question in a recent [Terraspace lightning talk](https://www.youtube.com/watch?v=L1IE2oJ1k00&feature=youtu.be&t=4995)

## Version Changes

Patch