### PR TITLE
fix find placeholder stack so config/terraform only builds for stacks

### DIFF
--- a/lib/terraspace/cli/build/placeholder.rb
+++ b/lib/terraspace/cli/build/placeholder.rb
@@ -18,17 +18,17 @@ module Terraspace::CLI::Build
       mod = @options[:mod]
       if !mod or %w[placeholder].include?(mod)
         logger.info "Building one of the modules to get backend.tf info"
-        mod = find_mod
+        mod = find_stack
       end
       Terraspace::Builder.new(@options.merge(mod: mod, init: false)).run # generate and init
       Terraspace::Mod.new(mod, @options) # mod metadata
     end
 
     # Used by: terraspace build placeholder
-    def find_mod
-      mod_path = Dir.glob("{app,vendor}/{modules,stacks}/*").last
+    def find_stack
+      mod_path = Dir.glob("{app,vendor}/{stacks}/*").last
       unless mod_path
-        logger.info "No modules or stacks found."
+        logger.info "No stacks found."
         exit 0
       end
       File.basename(mod_path) # mod name

--- a/lib/terraspace/mod.rb
+++ b/lib/terraspace/mod.rb
@@ -19,7 +19,7 @@ module Terraspace
 
     def placeholder(name)
       if name == "placeholder"
-        Terraspace::CLI::Build::Placeholder.new(@options).find_mod
+        Terraspace::CLI::Build::Placeholder.new(@options).find_stack
       else
         name
       end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes `terraspace build` so that it won't accidentally build `config/terraform` files to modules folder when the placeholder stack that is found happens to a be a module. Placeholder stacks should only be stacks.

## Context

Fixes #66

## How to Test

Go through QA matrix.

## Version Changes

Patch