### PR TITLE
require singleton

### DIFF
--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -1,3 +1,5 @@
+require "singleton"
+
 module Terraspace
   class App
     include Singleton


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* think upstream aws-sdk libraries remove require singleton so need to require it not explicitly

## How to Test

A generator reproduces this.

    terraspace new project infra --examples

## Version Changes

Patch