### PR TITLE
dont use auto generated plan when both yes and plan options used

### DIFF
--- a/lib/terraspace/cli/up.rb
+++ b/lib/terraspace/cli/up.rb
@@ -6,7 +6,7 @@ class Terraspace::CLI
 
     def run
       build
-      if @options[:yes] && !tfc?
+      if @options[:yes] && !@options[:plan] && !tfc?
         plan
         Commander.new("apply", @options.merge(plan: plan_path)).run
       else


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Make sure to use the provided plan when both the `--plan` and `--yes` options are used.

## Context

https://community.boltops.com/t/using-tf-plan-file/623

## How to Test

Deploy with a plan. IE:

    terraspace plan demo --out plan.save
    terraspace up demo --plan plan.save

## Version Changes

Patch