### PR TITLE
Fix: skip stacks in ignore_stacks list, while building the dependencies graph #80

### DIFF
--- a/lib/terraspace/dependency/graph.rb
+++ b/lib/terraspace/dependency/graph.rb
@@ -54,6 +54,12 @@ module Terraspace::Dependency
     def build_nodes_with_dependencies
       @dependencies.each do |item|
         parent_name, child_name = item.split(':')
+
+        if Terraspace.config.all.ignore_stacks.include? parent_name
+          logger.info("Stack: #{parent_name} skipped due to ignore_stacks configuration")
+          next
+        end
+
         save_node_parent(parent_name, child_name)
       end
     end


### PR DESCRIPTION
<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix for issue https://github.com/boltops-tools/terraspace/issues/80
- [x ] The test suite passes
## Summary
It just skip stacks that are ignored by **config.all.ignore_stacks** configuration parameter.

## How to Test
Try to reproduce bug described in https://github.com/boltops-tools/terraspace/issues/80

## Version Changes
patch

