### PR TITLE
Add all.include_stacks option and fix all.ignore_stacks option when building dependency graph

### DIFF
--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -17,8 +17,8 @@ module Terraspace
       config.all.exit_on_fail = ActiveSupport::OrderedOptions.new
       config.all.exit_on_fail.down = true
       config.all.exit_on_fail.up = true
-      config.all.include_stacks = nil
       config.all.ignore_stacks = nil
+      config.all.include_stacks = nil
       config.allow = ActiveSupport::OrderedOptions.new
       config.allow.envs = nil
       config.allow.regions = nil

--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -17,7 +17,8 @@ module Terraspace
       config.all.exit_on_fail = ActiveSupport::OrderedOptions.new
       config.all.exit_on_fail.down = true
       config.all.exit_on_fail.up = true
-      config.all.ignore_stacks = []
+      config.all.include_stacks = nil
+      config.all.ignore_stacks = nil
       config.allow = ActiveSupport::OrderedOptions.new
       config.allow.envs = nil
       config.allow.regions = nil

--- a/lib/terraspace/cli/build/placeholder.rb
+++ b/lib/terraspace/cli/build/placeholder.rb
@@ -26,7 +26,12 @@ module Terraspace::CLI::Build
 
     # Used by: terraspace build placeholder
     def find_stack
-      mod_path = Dir.glob("{app,vendor}/stacks/*").last
+      stack_paths = Dir.glob("{app,vendor}/stacks/*")
+      stack_paths.select! do |path|
+        select = Terraspace::Compiler::Select.new(path)
+        select.selected?
+      end
+      mod_path = stack_paths.last
       unless mod_path
         logger.info "No stacks found."
         exit 0

--- a/lib/terraspace/compiler/dirs_concern.rb
+++ b/lib/terraspace/compiler/dirs_concern.rb
@@ -23,6 +23,7 @@ module Terraspace::Compiler
       names, built = [], []
       local_paths(type_dir).each do |path|
         next unless File.directory?(path)
+        next unless select_stack?(type_dir, path)
         mod_name = File.basename(path)
         next if built.include?(mod_name) # ensures modules in app folder take higher precedence than vendor folder
         names << mod_name
@@ -30,6 +31,15 @@ module Terraspace::Compiler
       names
     end
     memoize :mod_names
+
+    # Examples:
+    #   type_dir stacks
+    #   path     /home/ec2-user/environment/downloads/infra/app/stacks/demo
+    def select_stack?(type_dir, path)
+      return true unless type_dir == "stacks"
+      select = Terraspace::Compiler::Select.new(path)
+      select.selected?
+    end
 
     def local_paths(type_dir)
       dirs("app/#{type_dir}/*") + dirs("vendor/#{type_dir}/*")
@@ -40,7 +50,7 @@ module Terraspace::Compiler
     end
 
     def stack_names
-      mod_names("stacks") - Terraspace.config.all.ignore_stacks
+      mod_names("stacks")
     end
     memoize :stack_names
   end

--- a/lib/terraspace/compiler/select.rb
+++ b/lib/terraspace/compiler/select.rb
@@ -1,0 +1,20 @@
+module Terraspace::Compiler
+  class Select
+    def initialize(path)
+      @path = path
+      @stack_name = extract_stack_name(path)
+    end
+
+    def selected?
+      !all.ignore_stacks.include?(@stack_name)
+    end
+
+    def all
+      Terraspace.config.all
+    end
+
+    def extract_stack_name(path)
+      path.sub(%r{.*(app|vendor)/stacks/}, '')
+    end
+  end
+end

--- a/lib/terraspace/compiler/select.rb
+++ b/lib/terraspace/compiler/select.rb
@@ -6,11 +6,19 @@ module Terraspace::Compiler
     end
 
     def selected?
-      !all.ignore_stacks.include?(@stack_name)
-    end
+      all = Terraspace.config.all
+      # Key difference between include_stacks vs all.include_stacks option is that
+      # the option can be nil. The local variable is guaranteed to be an Array.
+      # This simplifies the logic.
+      include_stacks = all.include_stacks || []
+      ignore_stacks  = all.ignore_stacks  || []
 
-    def all
-      Terraspace.config.all
+      if all.include_stacks.nil?
+        !ignore_stacks.include?(@stack_name)
+      else
+        stacks = include_stacks - ignore_stacks
+        stacks.include?(@stack_name)
+      end
     end
 
     def extract_stack_name(path)


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Add all.include_stacks option and fix all.ignore_stacks option when building dependency graph

## Context

Fixes #80 
Closes #81 

Huge thanks to @d-helios digging into this. In particular, for putting together a comprehensive project example.

## How to Test

Use the example project from #80

## Test ignore_stacks option

Build graph with ignored `demo-ssm` stack.

    $ grep ignore config/app.rb 
    config.all.ignore_stacks = ["demo-ssm"]
    $ terraspace all graph --format text
    Building graph...
    demo
    $ 
    
Build graph without ignored `demo-ssm` stack.

    $ grep ignore config/app.rb 
    $ terraspace all graph --format text
    Building graph...
    Downloading tfstate files for dependencies defined in tfvars...
    demo-ssm
    └── demo
    $

## Test include_stacks option

    $ grep include config/app.rb
      config.all.include_stacks = ["demo"]
    $ terraspace all graph --format text
    Building graph...
    demo
    $ 
    
## Test both options together

    $ grep all config/app.rb 
      config.all.include_stacks = ["demo"]
      config.all.ignore_stacks = ["demo-ssm"]
    $ terraspace all graph --format text
    Building graph...
    demo
    $ 

## Version Changes

Patch