### PR TITLE
rename cloud to tfc command and improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project *loosely tries* to adhere to [Semantic Versioning](http://semver.org/), even before v1.0.
 
+## [UNRELEASED]
+- Rename `terraspace cloud` to `terraspace tfc` and tfc improvements
+- Improve stdout handling, so this works: `terraspace show demo --json | jq`
+- `terraspace plan --output plan.save` writes to relative cache path.
+- `terraspace up --plan plan.save` copies plan.save to cache path.
+- Add state command. Initial simple version.
+
 ## [0.5.12] - 2021-02-27
 - [#79](https://github.com/boltops-tools/terraspace/pull/79) Fix syntax issue
 - [#85](https://github.com/boltops-tools/terraspace/pull/85) Add all.include_stacks option and fix all.ignore_stacks option when building dependency graph
@@ -108,7 +115,7 @@ This project *loosely tries* to adhere to [Semantic Versioning](http://semver.or
 * fix build for edge case when app/modules exist but app/stacks do not
 * terraspace new project: do not generate spec folder by default
 * improve all output summary
-* remove redundant `terraspace cloud setup`, instead use: `terraspace cloud sync`
+* remove redundant `terraspace tfc setup`, instead use: `terraspace tfc sync`
 * improve terraspace info output
 * fix integration test pipeline
 
@@ -127,8 +134,8 @@ This project *loosely tries* to adhere to [Semantic Versioning](http://semver.or
 * Terraspace log: view and tail log files
 * Terraspace logs management commands: `terraspace logs truncate` and `terraspace logs remove`
 * TFC/TFE: Improve support. `config.cloud.vars`, `config.cloud.workspace.attrs`
-* TFC commands: terraspace cloud runs list, terraspace cloud runs prune
-* TFC VCS also sync as part of deploy. Also separate `terraspace cloud sync` command
+* TFC commands: terraspace tfc runs list, terraspace tfc runs prune
+* TFC VCS also sync as part of deploy. Also separate `terraspace tfc sync` command
 * Logger improvements: configurable formatter, log to stderr by default
 * Rename: `cloud.relative_root` to `cloud.working_dir_prefix`
 * Run a plan to capture the diff as part of `-y` option. IE: `terraspace up demo -y`
@@ -161,11 +168,11 @@ This project *loosely tries* to adhere to [Semantic Versioning](http://semver.or
 * New expander variables: TYPE_INSTANCE, INSTANCE, CACHE_ROOT. Also added strip trailing - and / behavior.
 * Timeout for terraform init. The default timeout is 10m and will then print out the terraform init log.
 * Terraspace 0.2.x is compatible with terraspace\_plugin_aws 0.2.x, terraspace\_plugin_google 0.2.x, and terraspace\_plugin_azurerm 0.2.x
-* New commands: terraspace list, terraspace cloud list, terraspace cloud setup, terraspace cloud destroy, terraspace new shim, terraspace new git_hook
+* New commands: terraspace list, terraspace tfc list, terraspace tfc setup, terraspace tfc destroy, terraspace new shim, terraspace new git_hook
 * terraspace list: list of modules and stacks
-* terraspace cloud list: shows list of TFC workspaces
-* terraspace cloud setup: setups up TFC workspace for VCS-driven workflow. This automatically happens for the TFC CLI-driven workflow.
-* terraspace cloud destroy: destroys the TFC workspace associated with the stack. Can also use the `terraspace down demo --destroy-workspace` option.
+* terraspace tfc list: shows list of TFC workspaces
+* terraspace tfc setup: setups up TFC workspace for VCS-driven workflow. This automatically happens for the TFC CLI-driven workflow.
+* terraspace tfc destroy: destroys the TFC workspace associated with the stack. Can also use the `terraspace down demo --destroy-workspace` option.
 * terraspace new shim: An quick way to generate a terraspace shim.
 * terraspace new git_hook: An quick way to set up a git pre-push hook for the TFC VCS-driven workflow.
 * terraspace down: works even if there's no app/stacks folder. A fake stack is built.

--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -29,16 +29,6 @@ module Terraspace
       config.build.clean_cache = nil # defaults to /full/path/to/.terraspace-cache
       config.bundle = ActiveSupport::OrderedOptions.new
       config.bundle.logger = ts_logger
-      config.cloud = ActiveSupport::OrderedOptions.new
-      config.cloud.auto_sync = true
-      config.cloud.hostname = nil
-      config.cloud.vars = ActiveSupport::OrderedOptions.new
-      config.cloud.vars.overwrite = true
-      config.cloud.vars.overwrite_sensitive = true
-      config.cloud.vars.show_message = "create"
-      config.cloud.working_dir_prefix = nil
-      config.cloud.workspace = ActiveSupport::OrderedOptions.new
-      config.cloud.workspace.attrs = ActiveSupport::OrderedOptions.new
       config.hooks = Hooks.new
       config.init = ActiveSupport::OrderedOptions.new
       config.init.mode = "auto" # auto, never, always
@@ -47,12 +37,24 @@ module Terraspace
       config.logger = ts_logger
       config.logger.formatter = Logger::Formatter.new
       config.logger.level = ENV['TS_LOG_LEVEL'] || :info
+      config.summary = ActiveSupport::OrderedOptions.new
+      config.summary.prune = false
       config.terraform = ActiveSupport::OrderedOptions.new
       config.terraform.plugin_cache = ActiveSupport::OrderedOptions.new
       config.terraform.plugin_cache.dir = ENV['TF_PLUGIN_CACHE_DIR'] || "#{Terraspace.tmp_root}/plugin_cache"
       config.terraform.plugin_cache.enabled = true
       config.terraform.plugin_cache.purge_on_error = true
       config.test_framework = "rspec"
+      config.tfc = ActiveSupport::OrderedOptions.new
+      config.tfc.auto_sync = true
+      config.tfc.hostname = nil
+      config.tfc.vars = ActiveSupport::OrderedOptions.new
+      config.tfc.vars.overwrite = true
+      config.tfc.vars.overwrite_sensitive = true
+      config.tfc.vars.show_message = "create"
+      config.tfc.working_dir_prefix = nil
+      config.tfc.workspace = ActiveSupport::OrderedOptions.new
+      config.tfc.workspace.attrs = ActiveSupport::OrderedOptions.new
       config
     end
 

--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -10,7 +10,7 @@ module Terraspace
       option :format, desc: "output formats: json, text"
     }
     out_option = Proc.new {
-      option :out, aliases: :o, desc: "write the output to path"
+      option :out, aliases: :o, desc: "Write the output to path"
     }
     input_option = Proc.new {
       option :input, type: :boolean, desc: "Ask for input for variables if not directly set."
@@ -36,13 +36,13 @@ module Terraspace
     long_desc Help.text(:clean)
     subcommand "clean", Clean
 
-    desc "cloud SUBCOMMAND", "cloud subcommands"
-    long_desc Help.text(:cloud)
-    subcommand "cloud", Cloud
-
     desc "new SUBCOMMAND", "new subcommands"
     long_desc Help.text(:new)
     subcommand "new", New
+
+    desc "tfc SUBCOMMAND", "tfc subcommands"
+    long_desc Help.text(:tfc)
+    subcommand "tfc", Tfc
 
     desc "build [STACK]", "Build project."
     long_desc Help.text(:build)
@@ -123,6 +123,7 @@ module Terraspace
     instance_option.call
     out_option.call
     reconfigure_option.call
+    option :copy_to_root, type: :boolean, default: true, desc: "Copy plan file generated in the cache folder back to project root"
     def plan(mod)
       Commander.new("plan", options.merge(mod: mod)).run
     end
@@ -167,6 +168,12 @@ module Terraspace
     option :json, type: :boolean, desc: "show plan in json format"
     def show(mod)
       Commander.new("show", options.merge(mod: mod)).run
+    end
+
+    desc "state SUBCOMMAND STACK", "Run state."
+    long_desc Help.text(:state)
+    def state(subcommand, mod)
+      State.new(options.merge(subcommand: subcommand, mod: mod)).run
     end
 
     desc "test", "Run test."

--- a/lib/terraspace/cli/commander.rb
+++ b/lib/terraspace/cli/commander.rb
@@ -7,7 +7,7 @@ class Terraspace::CLI
 
     def run
       Terraspace::Builder.new(@options).run unless @options[:build] # Up already ran build
-      Init.new(@options.merge(calling_command: @name)).run
+      Init.new(@options).run
       Terraspace::Terraform::Runner.new(@name, @options).run
     end
   end

--- a/lib/terraspace/cli/down.rb
+++ b/lib/terraspace/cli/down.rb
@@ -14,7 +14,7 @@ class Terraspace::CLI
 
     def destroy
       Commander.new("destroy", @options.merge(command: "down")).run
-      Terraspace::Terraform::Cloud::Workspace.new(@options).destroy if @options[:destroy_workspace]
+      Terraspace::Terraform::Tfc::Workspace.new(@options).destroy if @options[:destroy_workspace]
     end
   end
 end

--- a/lib/terraspace/cli/help/tfc/destroy.md
+++ b/lib/terraspace/cli/help/tfc/destroy.md
@@ -1,6 +1,6 @@
 ## Example
 
-    $ terraspace cloud destroy demo
+    $ terraspace tfc destroy demo
     You are about to delete the workspace: demo-dev-us-west-2
     All variables, settings, run history, and state history will be removed.
     This cannot be undone.

--- a/lib/terraspace/cli/help/tfc/list.md
+++ b/lib/terraspace/cli/help/tfc/list.md
@@ -1,6 +1,6 @@
 ## Example
 
-    $ terraspace cloud list
+    $ terraspace tfc list
     Workspaces for boltops:
     demo-dev-us-west-2
     demo2-dev-us-west-2

--- a/lib/terraspace/cli/help/tfc/runs/list.md
+++ b/lib/terraspace/cli/help/tfc/runs/list.md
@@ -2,7 +2,7 @@
 
 Statuses of pending and planned are shown by default.
 
-    $ terraspace cloud runs list demo
+    $ terraspace tfc runs list demo
     +----------------------+---------+---------------------------------+---------------------+
     |          Id          | Status  |             Message             |     Created At      |
     +----------------------+---------+---------------------------------+---------------------+
@@ -13,7 +13,7 @@ Statuses of pending and planned are shown by default.
 
 To see all most recent runs, use `--status all`.
 
-    $ terraspace cloud runs list demo --status all
+    $ terraspace tfc runs list demo --status all
     +----------------------+-----------+--------------------------------+---------------------+
     |          Id          |  Status   |            Message             |     Created At      |
     +----------------------+-----------+--------------------------------+---------------------+
@@ -26,7 +26,7 @@ To see all most recent runs, use `--status all`.
 
 You can provide a list of statuses to the `--status` filter option.
 
-    $ terraspace cloud runs list demo --status canceled discarded
+    $ terraspace tfc runs list demo --status canceled discarded
     +----------------------+-----------+--------------------------------+---------------------+
     |          Id          |  Status   |            Message             |     Created At      |
     +----------------------+-----------+--------------------------------+---------------------+

--- a/lib/terraspace/cli/help/tfc/runs/prune.md
+++ b/lib/terraspace/cli/help/tfc/runs/prune.md
@@ -2,12 +2,12 @@ This leaves the top run alone. The top run usually starts immediately planning o
 
 ## Examples
 
-    terraspace cloud runs prune demo --noop
-    terraspace cloud runs prune demo # live run
+    terraspace tfc runs prune demo --noop
+    terraspace tfc runs prune demo # live run
 
 ## Example with Output
 
-    $ terraspace cloud runs prune demo
+    $ terraspace tfc runs prune demo
     Will keep:
 
         run-9muMrjrd22vhsP4u pending test 2020-09-18T12:47:11

--- a/lib/terraspace/cli/help/tfc/sync.md
+++ b/lib/terraspace/cli/help/tfc/sync.md
@@ -2,7 +2,7 @@
 
 Sync all stacks:
 
-    $ terraspace cloud sync
+    $ terraspace tfc sync
     About to sync these project stacks with Terraform Cloud workspaces:
 
         Stack => Workspace
@@ -22,7 +22,7 @@ Sync all stacks:
 
 Sync specific stacks:
 
-    $ terraspace cloud sync demo
+    $ terraspace tfc sync demo
     About to sync these project stacks with Terraform Cloud workspaces:
 
         Stack => Workspace
@@ -40,4 +40,4 @@ Sync specific stacks:
 
 Can also specify multiple stacks:
 
-    terraspace cloud sync demo demo2
+    terraspace tfc sync demo demo2

--- a/lib/terraspace/cli/state.rb
+++ b/lib/terraspace/cli/state.rb
@@ -1,0 +1,10 @@
+class Terraspace::CLI
+  class State < Base
+    def run
+      @name = "state #{@options[:subcommand]}" # command name. IE: state list
+      Terraspace::Builder.new(@options).run
+      Init.new(@options).run
+      Terraspace::Terraform::Runner.new(@name, @options).run
+    end
+  end
+end

--- a/lib/terraspace/cli/tfc.rb
+++ b/lib/terraspace/cli/tfc.rb
@@ -1,7 +1,7 @@
 class Terraspace::CLI
-  class Cloud < Terraspace::Command
-    Syncer = Terraspace::Terraform::Cloud::Syncer
-    Workspace = Terraspace::Terraform::Cloud::Workspace
+  class Tfc < Terraspace::Command
+    Syncer = Terraspace::Terraform::Tfc::Syncer
+    Workspace = Terraspace::Terraform::Tfc::Workspace
 
     yes_option = Proc.new {
       option :yes, aliases: :y, type: :boolean, desc: "bypass are you sure prompt"

--- a/lib/terraspace/cli/tfc/runs.rb
+++ b/lib/terraspace/cli/tfc/runs.rb
@@ -1,10 +1,10 @@
-class Terraspace::CLI::Cloud
+class Terraspace::CLI::Tfc
   class Runs < Terraspace::Command
     Help = Terraspace::CLI::Help
-    Runs = Terraspace::Terraform::Cloud::Runs
+    Runs = Terraspace::Terraform::Tfc::Runs
 
     desc "list STACK", "List runs."
-    long_desc Help.text("cloud:runs:list")
+    long_desc Help.text("tfc:runs:list")
     option :format, desc: "Output formats: #{CliFormat.formats.join(', ')}"
     option :status, default: %w[pending planned], type: :array, desc: "Filter by statuses: pending, planned, all"
     def list(mod)
@@ -12,7 +12,7 @@ class Terraspace::CLI::Cloud
     end
 
     desc "prune STACK", "Prune runs that are possible to cancel or discard."
-    long_desc Help.text("cloud:runs:prune")
+    long_desc Help.text("tfc:runs:prune")
     option :noop, type: :boolean, desc: "Shows what would be cancelled/discarded."
     option :yes, aliases: :y, type: :boolean, desc: "bypass are you sure prompt"
     def prune(mod)

--- a/lib/terraspace/logger.rb
+++ b/lib/terraspace/logger.rb
@@ -5,7 +5,7 @@ module Terraspace
     def initialize(*args)
       super
       self.formatter = Formatter.new
-      self.level = :info
+      self.level = ENV['TS_LOG_LEVEL'] || :info # note: only respected when config.logger not set in config/app.rb
     end
 
     def format_message(severity, datetime, progname, msg)
@@ -15,6 +15,13 @@ module Terraspace
         super # use the configured formatter
       end
       line =~ /\n$/ ? line : "#{line}\n"
+    end
+
+    # Used to allow terraform output to always go to stdout
+    # Terraspace output goes to stderr by default
+    # See: terraspace/shell.rb
+    def stdout(msg)
+      puts msg
     end
   end
 end

--- a/lib/terraspace/mod.rb
+++ b/lib/terraspace/mod.rb
@@ -75,7 +75,7 @@ module Terraspace
     #
     #   down - so user can delete stacks w/o needing to create an empty app/stacks/demo folder
     #   null - for the terraspace summary command when there are zero stacks.
-    #          Also useful for terraspace cloud list_workspaces
+    #          Also useful for terraspace tfc list_workspaces
     #
     def possible_fake_root
       if @options[:command] == "down"

--- a/lib/terraspace/plugin/summary/interface.rb
+++ b/lib/terraspace/plugin/summary/interface.rb
@@ -67,7 +67,7 @@ module Terraspace::Plugin::Summary
       return unless data # edge case: blank file
       resources = data['resources']
       return unless resources
-      remove_statefile(path) if resources && resources.size == 0 && !ENV['TS_KEEP_EMPTY_STATEFILES']
+      remove_statefile(path) if Terraspace.config.summary.prune && resources && resources.size == 0
       return unless resources && resources.size > 0
 
       pretty_path = path.sub(Regexp.new(".*#{@bucket}/#{@folder}"), '')

--- a/lib/terraspace/terraform/api/runs.rb
+++ b/lib/terraspace/terraform/api/runs.rb
@@ -8,8 +8,19 @@ class Terraspace::Terraform::Api
     end
 
     def list
-      payload = http.get("workspaces/#{@workspace_id}/runs")
-      payload['data'] if payload
+      data, next_page = [], :start
+      while next_page == :start || next_page
+        url = "workspaces/#{@workspace_id}/runs"
+        if next_page
+          qs = URI.encode_www_form('page[number]': next_page) if next_page
+          url += "?#{qs}"
+        end
+        payload = http.get(url)
+        return unless payload
+        data += payload['data']
+        next_page = payload['meta']['pagination']['next-page']
+      end
+      data
     end
 
     def discard(id)

--- a/lib/terraspace/terraform/api/token.rb
+++ b/lib/terraspace/terraform/api/token.rb
@@ -51,11 +51,11 @@ class Terraspace::Terraform::Api
     end
 
     def hostname
-      ENV['TS_HOST'] || Terraspace.config.cloud.hostname || 'app.terraform.io'
+      ENV['TFC_HOST'] || Terraspace.config.tfc.hostname || 'app.terraform.io'
     end
 
     def hostname_configured?
-      !!Terraspace.config.cloud.hostname
+      !!Terraspace.config.tfc.hostname
     end
 
     def self.get

--- a/lib/terraspace/terraform/api/var.rb
+++ b/lib/terraspace/terraform/api/var.rb
@@ -31,7 +31,7 @@ class Terraspace::Terraform::Api
     end
 
     def vars
-      Terraspace.config.cloud.vars
+      Terraspace.config.tfc.vars
     end
 
     def variable_id(key)

--- a/lib/terraspace/terraform/api/vars.rb
+++ b/lib/terraspace/terraform/api/vars.rb
@@ -33,7 +33,7 @@ class Terraspace::Terraform::Api
 
     def vars_path
       # .rb takes higher precedence
-      Dir.glob("#{Terraspace.root}/config/terraform/cloud/vars.{rb,json}").first
+      Dir.glob("#{Terraspace.root}/config/terraform/tfc/vars.{rb,json}").first
     end
   end
 end

--- a/lib/terraspace/terraform/api/vars/base.rb
+++ b/lib/terraspace/terraform/api/vars/base.rb
@@ -1,5 +1,7 @@
 class Terraspace::Terraform::Api::Vars
   class Base
+    include Terraspace::Util::Logging
+
     def initialize(mod, vars_path)
       @mod, @vars_path = mod, vars_path
     end

--- a/lib/terraspace/terraform/api/vars/json.rb
+++ b/lib/terraspace/terraform/api/vars/json.rb
@@ -4,11 +4,23 @@ class Terraspace::Terraform::Api::Vars
       context = Terraspace::Compiler::Erb::Context.new(@mod)
       result = RenderMePretty.result(@vars_path, context: context)
 
-      data = JSON.load(result)
+      data = json_load(result)
       items = data.select do |item|
         item['data']['type'] == 'vars'
       end
       items.map { |i| i['data']['attributes'] }
+    end
+
+    def json_load(result)
+      JSON.load(result)
+    rescue JSON::ParserError => e
+      # TODO: show exact line with error
+      logger.info("ERROR in json: #{e.class}: #{e.message}")
+      path = "/tmp/terraspace/debug/vars.json"
+      logger.info("Result also written to #{path} for inspection")
+      FileUtils.mkdir_p(File.dirname(path))
+      IO.write(path, result)
+      exit 1
     end
   end
 end

--- a/lib/terraspace/terraform/ihooks/after/plan.rb
+++ b/lib/terraspace/terraform/ihooks/after/plan.rb
@@ -1,0 +1,17 @@
+module Terraspace::Terraform::Ihooks::After
+  class Plan < Terraspace::Terraform::Ihooks::Base
+    def run
+      return if !@options[:out] || @options[:copy_to_root] == false
+      copy_to_root(@options[:out])
+    end
+
+    def copy_to_root(file)
+      return if file =~ %r{^/} # not need to copy absolute path
+      name = file.sub("#{Terraspace.root}/",'')
+      src = "#{@mod.cache_dir}/#{name}"
+      dest = name
+      FileUtils.mkdir_p(File.dirname(dest))
+      FileUtils.cp(src, dest)
+    end
+  end
+end

--- a/lib/terraspace/terraform/ihooks/base.rb
+++ b/lib/terraspace/terraform/ihooks/base.rb
@@ -1,0 +1,8 @@
+module Terraspace::Terraform::Ihooks
+  class Base < Terraspace::CLI::Base
+    def initialize(name, options={})
+      @name = name
+      super(options)
+    end
+  end
+end

--- a/lib/terraspace/terraform/ihooks/before/plan.rb
+++ b/lib/terraspace/terraform/ihooks/before/plan.rb
@@ -1,0 +1,14 @@
+module Terraspace::Terraform::Ihooks::Before
+  class Plan < Terraspace::Terraform::Ihooks::Base
+    def run
+      out = @options[:out]
+      return unless out
+      return if out =~ %r{^/} # not need to create parent dir for copy with absolute path
+
+      out = @options[:out]
+      name = out.sub("#{Terraspace.root}/",'')
+      dest = "#{@mod.cache_dir}/#{name}"
+      FileUtils.mkdir_p(File.dirname(dest))
+    end
+  end
+end

--- a/lib/terraspace/terraform/remote_state/fetcher.rb
+++ b/lib/terraspace/terraform/remote_state/fetcher.rb
@@ -84,7 +84,7 @@ module Terraspace::Terraform::RemoteState
     end
 
     def init
-      Terraspace::CLI::Init.new(mod: @child.name, calling_command: "apply", quiet: true, suppress_error_color: true).init
+      Terraspace::CLI::Init.new(mod: @child.name, quiet: true, suppress_error_color: true).init
       true
     rescue Terraspace::BucketNotFoundError # from Terraspace::Shell
       bucket_not_found_error

--- a/lib/terraspace/terraform/tfc/runs.rb
+++ b/lib/terraspace/terraform/tfc/runs.rb
@@ -1,4 +1,4 @@
-module Terraspace::Terraform::Cloud
+module Terraspace::Terraform::Tfc
   class Runs < Terraspace::CLI::Base
     def list
       lister = Lister.new(@mod, @options)

--- a/lib/terraspace/terraform/tfc/runs/base.rb
+++ b/lib/terraspace/terraform/tfc/runs/base.rb
@@ -1,4 +1,4 @@
-class Terraspace::Terraform::Cloud::Runs
+class Terraspace::Terraform::Tfc::Runs
   class Base
     extend Memoist
     include Terraspace::Util::Logging

--- a/lib/terraspace/terraform/tfc/runs/item_presenter.rb
+++ b/lib/terraspace/terraform/tfc/runs/item_presenter.rb
@@ -1,4 +1,4 @@
-class Terraspace::Terraform::Cloud::Runs
+class Terraspace::Terraform::Tfc::Runs
   class ItemPresenter
     attr_reader :id
     def initialize(raw)

--- a/lib/terraspace/terraform/tfc/runs/lister.rb
+++ b/lib/terraspace/terraform/tfc/runs/lister.rb
@@ -1,4 +1,4 @@
-class Terraspace::Terraform::Cloud::Runs
+class Terraspace::Terraform::Tfc::Runs
   class Lister < Base
     def run
       build_project

--- a/lib/terraspace/terraform/tfc/runs/pruner.rb
+++ b/lib/terraspace/terraform/tfc/runs/pruner.rb
@@ -1,4 +1,4 @@
-class Terraspace::Terraform::Cloud::Runs
+class Terraspace::Terraform::Tfc::Runs
   class Pruner < Base
     include Terraspace::Terraform::Api::Client
 

--- a/lib/terraspace/terraform/tfc/sync.rb
+++ b/lib/terraspace/terraform/tfc/sync.rb
@@ -1,4 +1,4 @@
-module Terraspace::Terraform::Cloud
+module Terraspace::Terraform::Tfc
   class Sync < Terraspace::CLI::Base
     extend Memoist
     include Terraspace::Terraform::Api::Client
@@ -16,7 +16,7 @@ module Terraspace::Terraform::Cloud
     # So we check and create the workspace if necessary.
     def run
       # Note: workspace still gets created by `terraform init` However, variables wont be sync if returns early
-      return unless Terraspace.config.cloud.auto_sync || @options[:override_auto_sync]
+      return unless Terraspace.config.tfc.auto_sync || @options[:override_auto_sync]
       return unless workspaces_backend?
       logger.info "Syncing to Terraform Cloud: #{@mod.name} => #{workspace_name}"
       @api = Terraspace::Terraform::Api.new(@mod, remote)

--- a/lib/terraspace/terraform/tfc/syncer.rb
+++ b/lib/terraspace/terraform/tfc/syncer.rb
@@ -1,4 +1,4 @@
-module Terraspace::Terraform::Cloud
+module Terraspace::Terraform::Tfc
   class Syncer < Terraspace::CLI::Base
     extend Memoist
     include Terraspace::Compiler::DirsConcern

--- a/lib/terraspace/terraform/tfc/workspace.rb
+++ b/lib/terraspace/terraform/tfc/workspace.rb
@@ -1,4 +1,4 @@
-module Terraspace::Terraform::Cloud
+module Terraspace::Terraform::Tfc
   class Workspace < Terraspace::CLI::Base
     extend Memoist
     include Terraspace::Util::Logging
@@ -21,7 +21,7 @@ module Terraspace::Terraform::Cloud
     end
 
     def init
-      Terraspace::CLI::Init.new(@options.merge(calling_command: "cloud-setup")).run
+      Terraspace::CLI::Init.new(@options).run
     end
 
     def create
@@ -72,4 +72,3 @@ module Terraspace::Terraform::Cloud
     end
   end
 end
-

--- a/lib/terraspace/util/pretty.rb
+++ b/lib/terraspace/util/pretty.rb
@@ -12,7 +12,8 @@ module Terraspace::Util
     end
 
     def pretty_path(path)
-      ENV['TS_TEST'] ? path : path.sub("#{Terraspace.root}/",'')
+      return path if ENV['TS_TEST']
+      path.sub("#{Terraspace.root}/",'').sub(ENV['HOME'], '~')
     end
   end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Rename `terraspace cloud` to `terraspace tfc`. Also, a few notable improvements.

* improve stdout handling: `terraspace show demo --json | jq` works
* improve error handling
* tfc runs: improve not found error and pagination list
* rename cloud to tfc command
* add terraspace state command. initial version related #45

## How to Test

Full regression test.

## Version Changes

Minor