### PR TITLE
custom layering support

### DIFF
--- a/lib/terraspace/app/inits.rb
+++ b/lib/terraspace/app/inits.rb
@@ -1,0 +1,13 @@
+class Terraspace::App
+  class Inits
+    class << self
+      include DslEvaluator
+
+      def run_all
+        Dir.glob("#{Terraspace.root}/config/inits/*.rb").each do |path|
+          evaluate_file(path)
+        end
+      end
+    end
+  end
+end

--- a/lib/terraspace/booter.rb
+++ b/lib/terraspace/booter.rb
@@ -5,6 +5,7 @@ module Terraspace
       load_plugin_default_configs
       Terraspace.config # load project config
       Terraspace::App::Hooks.run_hook(:on_boot)
+      Terraspace::App::Inits.run_all
       set_plugin_cache!
     end
 

--- a/lib/terraspace/compiler/builder.rb
+++ b/lib/terraspace/compiler/builder.rb
@@ -39,6 +39,7 @@ module Terraspace::Compiler
       expr = "#{Terraspace.root}/config/terraform/**/*"
       Dir.glob(expr).each do |path|
         next unless File.file?(path)
+        next if path.include?('config/terraform/tfvars')
         build_config_file(basename(path))
       end
     end
@@ -73,6 +74,7 @@ module Terraspace::Compiler
     def skip?(src_path)
       return true unless File.file?(src_path)
       # certain folders will be skipped
+      src_path.include?("#{@mod.root}/tfvars") ||
       src_path.include?("#{@mod.root}/config/args") ||
       src_path.include?("#{@mod.root}/config/hooks") ||
       src_path.include?("#{@mod.root}/test")

--- a/lib/terraspace/compiler/strategy/tfvar/layer.rb
+++ b/lib/terraspace/compiler/strategy/tfvar/layer.rb
@@ -1,11 +1,51 @@
+# Layers in order
+#
+#     Name / Pattern                 | Example
+#     -------------------------------|---------------
+#     base                           | base.tfvars
+#     env                            | dev.tfvars
+#     region/base                    | us-west-2/base.tfvars (provider specific)
+#     region/env                     | us-west-2/dev.tfvars (provider specific)
+#     namespace/base                 | 112233445566/base.tfvars (provider specific)
+#     namespace/env                  | 112233445566/dev.tfvars (provider specific)
+#     namespace/region/base          | 112233445566/us-west-2/base.tfvars (provider specific)
+#     namespace/region/env           | 112233445566/us-west-2/dev.tfvars (provider specific)
+#     provider/base                  | aws/base.tfvars (provider specific)
+#     provider/env                   | aws/dev.tfvars (provider specific)
+#     provider/region/base           | aws/us-west-2/base.tfvars (provider specific)
+#     provider/region/env            | aws/us-west-2/dev.tfvars (provider specific)
+#     provider/namespace/base        | aws/112233445566/base.tfvars (provider specific)
+#     provider/namespace/env         | aws/112233445566/dev.tfvars (provider specific)
+#     provider/namespace/region/base | aws/112233445566/us-west-2/base.tfvars (provider specific)
+#     provider/namespace/region/env  | aws/112233445566/us-west-2/dev.tfvars (provider specific)
+#
+# namespace and region depends on the provider. Here an example of the mapping:
+#
+#              | AWS     | Azure        | Google
+#    ----------|---------|--------------|-------
+#    namespace | account | subscription | project
+#    region    | region  | location     | region
+#
+#
 class Terraspace::Compiler::Strategy::Tfvar
   class Layer
+    extend Memoist
+    include Terraspace::Layering
+    include Terraspace::Plugin::Expander::Friendly
+
     def initialize(mod)
       @mod = mod
     end
 
     def paths
-      layer_paths = layers.map do |layer|
+      project_paths = full_paths(project_tfvars_dir)
+      stack_paths   = full_paths(stack_tfvars_dir)
+      project_paths + stack_paths
+    end
+    memoize :paths
+
+    def full_paths(tfvars_dir)
+      layer_paths = full_layering.map do |layer|
         [
           "#{tfvars_dir}/#{layer}.tfvars",
           "#{tfvars_dir}/#{layer}.rb",
@@ -17,60 +57,12 @@ class Terraspace::Compiler::Strategy::Tfvar
       end
     end
 
-    # Layers in order
-    #
-    #     Name / Pattern                 | Example
-    #     -------------------------------|---------------
-    #     base                           | base.tfvars
-    #     env                            | dev.tfvars
-    #     region/base                    | us-west-2/base.tfvars (provider specific)
-    #     region/env                     | us-west-2/dev.tfvars (provider specific)
-    #     namespace/base                 | 112233445566/base.tfvars (provider specific)
-    #     namespace/env                  | 112233445566/dev.tfvars (provider specific)
-    #     namespace/region/base          | 112233445566/us-west-2/base.tfvars (provider specific)
-    #     namespace/region/env           | 112233445566/us-west-2/dev.tfvars (provider specific)
-    #     provider/base                  | aws/base.tfvars (provider specific)
-    #     provider/env                   | aws/dev.tfvars (provider specific)
-    #     provider/region/base           | aws/us-west-2/base.tfvars (provider specific)
-    #     provider/region/env            | aws/us-west-2/dev.tfvars (provider specific)
-    #     provider/namespace/base        | aws/112233445566/base.tfvars (provider specific)
-    #     provider/namespace/env         | aws/112233445566/dev.tfvars (provider specific)
-    #     provider/namespace/region/base | aws/112233445566/us-west-2/base.tfvars (provider specific)
-    #     provider/namespace/region/env  | aws/112233445566/us-west-2/dev.tfvars (provider specific)
-    #
-    # namespace and region depends on the provider. Here an example of the mapping:
-    #
-    #              | AWS     | Azure        | Google
-    #    ----------|---------|--------------|-------
-    #    namespace | account | subscription | project
-    #    region    | region  | location     | region
-    #
-    #
-    def layers
-      layer_levels + plugin_layers
-    end
-
-    def plugin_layers
-      layers = []
-      Terraspace::Plugin.layer_classes.each do |klass|
-        layer = klass.new
-
-        # region is high up because its simpler and the more common case is a single provider
-        layers += layer_levels(layer.region)
-
-        # namespace is a simple way keep different tfvars between different engineers on different accounts
-        layers += layer_levels(layer.namespace)
-        layers += layer_levels("#{layer.namespace}/#{layer.region}")
-
-        # in case using multiple providers and one region
-        layers += layer_levels(layer.provider)
-        layers += layer_levels("#{layer.provider}/#{layer.region}") # also in case another provider has colliding regions
-
-        # Most general layering
-        layers += layer_levels("#{layer.provider}/#{layer.namespace}")
-        layers += layer_levels("#{layer.provider}/#{layer.namespace}/#{layer.region}")
+    def full_layering
+      # layers is defined in Terraspace::Layering module
+      layers.inject([]) do |sum, layer|
+        sum += layer_levels(layer) unless layer.nil?
+        sum
       end
-      layers
     end
 
     # adds prefix and to each layer pair that has base and Terraspace.env. IE:
@@ -79,12 +71,44 @@ class Terraspace::Compiler::Strategy::Tfvar
     #    "#{prefix}/#{Terraspace.env}"
     #
     def layer_levels(prefix=nil)
-      levels = ["base", Terraspace.env, @mod.instance] # layer levels
+      levels = ["base", Terraspace.env, @mod.instance].reject(&:blank?) # layer levels. @mod.instance can be nil
       env_levels = levels.map { |l| "#{Terraspace.env}/#{l}" } # env folder also
       levels = levels + env_levels
-      levels.map do |i|
-        [prefix, i].compact.join('/')
+      levels.map! do |i|
+        # base layer has prefix of '', reject with blank so it doesnt produce '//'
+        [prefix, i].reject(&:blank?).join('/')
       end
+      levels.unshift(prefix) unless prefix.blank? # IE: tfvars/us-west-2.tfvars
+      levels
+    end
+
+    def plugins
+      layers = []
+      Terraspace::Plugin.layer_classes.each do |klass|
+        layer = klass.new
+
+        # region is high up because its simpler and the more common case is a single provider
+        layers << layer.region
+
+        namespace = friendly_name(layer.namespace)
+
+        # namespace is a simple way keep different tfvars between different engineers on different accounts
+        layers << namespace
+        layers << "#{namespace}/#{layer.region}"
+
+        # in case using multiple providers and one region
+        layers << layer.provider
+        layers << "#{layer.provider}/#{layer.region}" # also in case another provider has colliding regions
+
+        # Most general layering
+        layers << "#{layer.provider}/#{namespace}"
+        layers << "#{layer.provider}/#{namespace}/#{layer.region}"
+      end
+      layers
+    end
+
+    def project_tfvars_dir
+      "#{Terraspace.root}/config/terraform/tfvars"
     end
 
     # seed dir takes higher precedence than the tfvars folder within the stack module. Example:
@@ -98,13 +122,12 @@ class Terraspace::Compiler::Strategy::Tfvar
     # Will also consider app/modules/demo/tfvars. Though modules to be reuseable and stacks is where business logic
     # should go.
     #
-    def tfvars_dir
+    def stack_tfvars_dir
       seed_dir = "#{Terraspace.root}/seed/tfvars/#{@mod.build_dir(disable_instance: true)}"
       mod_dir = "#{@mod.root}/tfvars"
 
       empty = Dir.glob("#{seed_dir}/*").empty?
       empty ? mod_dir : seed_dir
     end
-
   end
 end

--- a/lib/terraspace/layering.rb
+++ b/lib/terraspace/layering.rb
@@ -1,0 +1,24 @@
+require "active_support/lazy_load_hooks"
+
+module Terraspace
+  module Layering
+    def layers
+      pre_layers + main_layers + post_layers
+    end
+
+    def main_layers
+      # '' prefix for base layer
+      [''] + plugins
+    end
+
+    def pre_layers
+      []
+    end
+
+    def post_layers
+      []
+    end
+  end
+end
+
+ActiveSupport.run_load_hooks(:terraspace_layering, Terraspace::Layering)

--- a/lib/terraspace/plugin/expander/friendly.rb
+++ b/lib/terraspace/plugin/expander/friendly.rb
@@ -1,0 +1,10 @@
+module Terraspace::Plugin::Expander
+  module Friendly
+    # used by
+    #   Terraspace::Compiler::Strategy::Tfvar::Layer
+    #   Terraspace::Plugin::Expander::Interface
+    def friendly_name(name)
+      Terraspace.config.layering.names[name.to_sym] || name
+    end
+  end
+end

--- a/lib/terraspace/plugin/expander/interface.rb
+++ b/lib/terraspace/plugin/expander/interface.rb
@@ -7,6 +7,7 @@
 module Terraspace::Plugin::Expander
   module Interface
     include Terraspace::Plugin::InferProvider
+    include Terraspace::Plugin::Expander::Friendly
 
     delegate :build_dir, :type_dir, :type, to: :mod
 
@@ -68,7 +69,11 @@ module Terraspace::Plugin::Expander
 
     def var_value(name)
       name = name.sub(':','').downcase
-      send(name)
+      value = send(name)
+      if name == "namespace" && Terraspace.config.layering.enable_names.cache_dir
+        value = friendly_name(value)
+      end
+      value
     end
 
     def mod_name


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* refactor layers allow easy customization
* Terraspace::Layering module for easy overrides
* pre_layer, post_layer, main_layer interface
* deprecate config/env for config/envs
* config/inits concetp
* improve generated tfvars name
* project-level layering
* tfvars folder wont be copied as an artifact
* rjust and pad 0 only when more than 9 layers
* namespace friendly names mapping
* cache dir customization with object.call
* layering.enable_names.cache_dir setting

## Context

* https://community.boltops.com/t/customized-layering-support/632/6
* https://community.boltops.com/t/pass-gcp-credentials-to-tfc/631/7

## How to Test

Full regression test.

## Version Changes

Minor