### PR TITLE
rename option to enable_names.expansion

### DIFF
--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -40,7 +40,7 @@ module Terraspace
       config.layering = ActiveSupport::OrderedOptions.new
       config.layering.names = {}
       config.layering.enable_names = ActiveSupport::OrderedOptions.new
-      config.layering.enable_names.cache_dir = true
+      config.layering.enable_names.expansion = true
       config.summary = ActiveSupport::OrderedOptions.new
       config.summary.prune = false
       config.terraform = ActiveSupport::OrderedOptions.new

--- a/lib/terraspace/plugin/expander/interface.rb
+++ b/lib/terraspace/plugin/expander/interface.rb
@@ -70,7 +70,7 @@ module Terraspace::Plugin::Expander
     def var_value(name)
       name = name.sub(':','').downcase
       value = send(name)
-      if name == "namespace" && Terraspace.config.layering.enable_names.cache_dir
+      if name == "namespace" && Terraspace.config.layering.enable_names.expansion
         value = friendly_name(value)
       end
       value


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Rename `layering.enable_names.cache_dir` to `layering.enable_names.expansion`.

## Version Changes

Patch