### PR TITLE
Camelcase

### DIFF
--- a/lib/terraspace/cli/new/helper.rb
+++ b/lib/terraspace/cli/new/helper.rb
@@ -26,9 +26,9 @@ class Terraspace::CLI::New
 
     def helper_class
       if type == "project"
-        "Terraspace::#{type.camelize}::#{name.camelize}Helper"
+        "Terraspace::#{type.camelcase}::#{name.camelcase}Helper"
       else
-        "Terraspace::#{type.camelize}::#{stack.camelize}::#{name.camelize}Helper"
+        "Terraspace::#{type.camelcase}::#{stack.camelcase}::#{name.camelcase}Helper"
       end
     end
 

--- a/lib/terraspace/compiler/builder.rb
+++ b/lib/terraspace/compiler/builder.rb
@@ -74,10 +74,11 @@ module Terraspace::Compiler
     def skip?(src_path)
       return true unless File.file?(src_path)
       # certain folders will be skipped
-      src_path.include?("#{@mod.root}/tfvars") ||
       src_path.include?("#{@mod.root}/config/args") ||
+      src_path.include?("#{@mod.root}/config/helpers") ||
       src_path.include?("#{@mod.root}/config/hooks") ||
-      src_path.include?("#{@mod.root}/test")
+      src_path.include?("#{@mod.root}/test") ||
+      src_path.include?("#{@mod.root}/tfvars")
     end
   end
 end

--- a/lib/terraspace/compiler/helper_extender.rb
+++ b/lib/terraspace/compiler/helper_extender.rb
@@ -5,7 +5,7 @@ module Terraspace::Compiler
       full_dir = "#{@mod.root}/config/helpers"
       Dir.glob("#{full_dir}/**/*").each do |path|
         regexp = Regexp.new(".*/helpers/")
-        klass = path.sub(regexp, '').sub('.rb','').camelize
+        klass = path.sub(regexp, '').sub('.rb','').camelcase
         klass = "#{mod_namespace}::#{klass}"
         require path # able to use require instead of load since each helper has unique namespace
         send :extend, klass.constantize
@@ -15,8 +15,8 @@ module Terraspace::Compiler
     # IE: mod_namespace = Terraspace::Module::Demo
     # Use separate namespaces scope with module name so custom helper methods from different modules are isolated.
     def mod_namespace
-      mod_name = @mod.name.camelize
-      ns = "Terraspace::#{@mod.type.camelize}".constantize # IE: Terraspace::Module or Terraspace::Stack
+      mod_name = @mod.name.camelcase
+      ns = "Terraspace::#{@mod.type.camelcase}".constantize # IE: Terraspace::Module or Terraspace::Stack
       if ns.const_defined?(mod_name.to_sym)
         "#{ns}::#{mod_name}".constantize
       else

--- a/lib/terraspace/ext.rb
+++ b/lib/terraspace/ext.rb
@@ -1,2 +1,3 @@
 require_relative "ext/bundler"
 require_relative "ext/core/module"
+require_relative "ext/core/string"

--- a/lib/terraspace/ext/core/string.rb
+++ b/lib/terraspace/ext/core/string.rb
@@ -1,0 +1,5 @@
+class String
+  def camelcase
+    self.underscore.camelize
+  end
+end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Allow stack names to have dashes in addition to underscore

## Context

https://community.boltops.com/t/wrong-constant-name-nameerror-for-helper-and-stack-name-with-hyphens/650/2

## How to Test

    terraspace new project testcase1
    cd testcase1
    terraspace new stack app-case1
    terraspace new helper app-case1 --type stack --name module_versions
    terraspace build

Note you still have to and should name modules with underscore. Good: module_versions Bad: module-versions

## Version Changes

Patch