### PR TITLE
disable terraform.plugin_cache by default

### DIFF
--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -45,7 +45,7 @@ module Terraspace
       config.terraform = ActiveSupport::OrderedOptions.new
       config.terraform.plugin_cache = ActiveSupport::OrderedOptions.new
       config.terraform.plugin_cache.dir = ENV['TF_PLUGIN_CACHE_DIR'] || "#{Terraspace.tmp_root}/plugin_cache"
-      config.terraform.plugin_cache.enabled = true
+      config.terraform.plugin_cache.enabled = false
       config.terraform.plugin_cache.purge_on_error = true
       config.test_framework = "rspec"
       config.tfc = ActiveSupport::OrderedOptions.new


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is an 🙋‍♂️ enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Change default to `config.terraform.plugin_cache.enabled = false'

https://terraspace.cloud/docs/config/reference/

## Context

https://community.boltops.com/t/planning-multiple-environments-back-to-back-fails-getting-providers/645/4

## How to Test

See: https://community.boltops.com/t/planning-multiple-environments-back-to-back-fails-getting-providers/645/4

## Version Changes

Patch