### PR TITLE
terraspace fmt command

### DIFF
--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -82,6 +82,12 @@ module Terraspace
       Down.new(options.merge(mod: mod)).run
     end
 
+    desc "fmt", "Run terraform fmt"
+    long_desc Help.text(:fmt)
+    def fmt
+      Fmt.new(options).run
+    end
+
     desc "info STACK", "Get info about stack."
     long_desc Help.text(:info)
     instance_option.call

--- a/lib/terraspace/cli/concerns/source_dirs.rb
+++ b/lib/terraspace/cli/concerns/source_dirs.rb
@@ -1,0 +1,13 @@
+module Terraspace::CLI::Concerns
+  module SourceDirs
+    # used by list
+    def source_dirs
+      Dir.glob("{app,vendor}/{modules,stacks}/*").select { |p| File.directory?(p) }.sort
+    end
+
+    # dont include vendor: used by fmt
+    def app_source_dirs
+      Dir.glob("{app}/{modules,stacks}/*").select { |p| File.directory?(p) }.sort
+    end
+  end
+end

--- a/lib/terraspace/cli/fmt.rb
+++ b/lib/terraspace/cli/fmt.rb
@@ -1,0 +1,21 @@
+class Terraspace::CLI
+  class Fmt
+    include Concerns::SourceDirs
+    include Terraspace::Util::Logging
+
+    def initialize(options={})
+      @options = options
+    end
+
+    def run
+      logger.info "Formating terraform files"
+      app_source_dirs.each do |dir|
+        format(dir)
+      end
+    end
+
+    def format(dir)
+      Runner.new(dir).format!
+    end
+  end
+end

--- a/lib/terraspace/cli/fmt/runner.rb
+++ b/lib/terraspace/cli/fmt/runner.rb
@@ -1,0 +1,64 @@
+class Terraspace::CLI::Fmt
+  class Runner
+    include Terraspace::CLI::Concerns::SourceDirs
+    include Terraspace::Util::Logging
+    SKIP_PATTERN = /\.skip$/
+
+    def initialize(dir)
+      @dir = dir
+    end
+
+    def format!
+      logger.info @dir.color(:green)
+      Dir.chdir(@dir) do
+        skip_rename
+        begin
+          terraform_fmt
+        ensure
+          restore_rename
+        end
+      end
+    end
+
+    def skip_rename
+      tf_files.each do |path|
+        if !skip?(path) && erb?(path)
+          FileUtils.mv(path, "#{path}.skip")
+        end
+      end
+    end
+
+    def terraform_fmt
+      sh "terraform fmt"
+    end
+
+    def sh(command)
+      logger.debug("=> #{command}")
+      success = system(command)
+      return if success
+      logger.info "WARN: There were some errors running terraform fmt for files in #{@dir}:".color(:yellow)
+      logger.info "The errors are shown above"
+    end
+
+    def restore_rename
+      tf_files.each do |path|
+        if skip?(path) && erb?(path)
+          FileUtils.mv(path, path.sub(SKIP_PATTERN, '')) # original name
+        end
+      end
+    end
+
+  private
+    def skip?(path)
+      !!(path =~ SKIP_PATTERN)
+    end
+
+    def erb?(path)
+      IO.readlines(path).detect { |l| l.include?('<%') }
+    end
+
+    def tf_files
+      Dir.glob("#{Terraspace.root}/#{@dir}/**/*.{tf,skip}").select { |p| File.file?(p) }
+    end
+  end
+end

--- a/lib/terraspace/cli/help/fmt.md
+++ b/lib/terraspace/cli/help/fmt.md
@@ -1,0 +1,10 @@
+## Example
+
+    $ terraspace fmt
+    Formating terraform files
+    app/modules/example
+    main.tf
+    outputs.tf
+    variables.tf
+    app/stacks/demo
+    main.tf

--- a/lib/terraspace/cli/list.rb
+++ b/lib/terraspace/cli/list.rb
@@ -1,13 +1,14 @@
 class Terraspace::CLI
   class List
+    include Concerns::SourceDirs
+
     def initialize(options={})
       @options = options
       @type_dir = normalized_type
     end
 
     def run
-      dirs = Dir.glob("{app,vendor}/{modules,stacks}/*").select { |p| File.directory?(p) }
-      dirs.sort.each do |path|
+      source_dirs.each do |path|
         if @type_dir
           puts path if path.include?("/#{@type_dir}/")
         else


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Add `terraspace fmt` command. It'll format all the source tf files in the app folder. So both `app/modules` and `app/stacks`.  

* Will skip files that contain ERB. 
* Only format files that have pure terraform code

## Context

https://community.boltops.com/t/terraform-fmt-borked-when-using-terraspace-templating/659

## How to Test

Run

    terraspace fmt

Check the tf files in `app` folder.

## Version Changes

Patch