### PR TITLE
terraspace fmt: ability to specific module or stack

### DIFF
--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -27,6 +27,9 @@ module Terraspace
     reconfigure_option = Proc.new {
       option :reconfigure, type: :boolean, desc: "Add terraform -reconfigure option"
     }
+    type_option = Proc.new {
+      option :type, default: "stack", aliases: %w[t], desc: "Type: stack, module, or all"
+    }
 
     desc "all SUBCOMMAND", "all subcommands"
     long_desc Help.text(:all)
@@ -84,8 +87,9 @@ module Terraspace
 
     desc "fmt", "Run terraform fmt"
     long_desc Help.text(:fmt)
-    def fmt
-      Fmt.new(options).run
+    type_option.call
+    def fmt(mod=nil)
+      Fmt.new(options.merge(mod: mod)).run
     end
 
     desc "info STACK", "Get info about stack."
@@ -106,7 +110,7 @@ module Terraspace
 
     desc "list", "List stacks and modules."
     long_desc Help.text(:list)
-    option :type, default: "stack", aliases: %w[t], desc: "Type: stack, module, or all"
+    type_option.call
     def list
       List.new(options).run
     end

--- a/lib/terraspace/cli/fmt.rb
+++ b/lib/terraspace/cli/fmt.rb
@@ -5,17 +5,36 @@ class Terraspace::CLI
 
     def initialize(options={})
       @options = options
+      @mod_name = options[:mod]
     end
 
     def run
       logger.info "Formating terraform files"
-      app_source_dirs.each do |dir|
+      dirs.each do |dir|
         format(dir)
       end
     end
 
     def format(dir)
       Runner.new(dir).format!
+    end
+
+  private
+    def dirs
+      if @mod_name
+        type_dirs.select { |p| p.include?(@mod_name) }
+      else
+        type_dirs
+      end
+    end
+
+    def type_dirs
+      type = @options[:type]
+      if type
+        app_source_dirs.select { |p| p.include?("/#{type.pluralize}/") }
+      else
+        app_source_dirs
+      end
     end
   end
 end

--- a/lib/terraspace/cli/help/fmt.md
+++ b/lib/terraspace/cli/help/fmt.md
@@ -1,5 +1,7 @@
 ## Example
 
+Format all source files.
+
     $ terraspace fmt
     Formating terraform files
     app/modules/example
@@ -8,3 +10,13 @@
     variables.tf
     app/stacks/demo
     main.tf
+
+Format specific module or stack.
+
+    $ terraspace fmt stack1
+    $ terraspace fmt module1
+
+Format scoping to module or stack types. In case there's a module and stack with the same name.
+
+    $ terraspace fmt example -t module
+    $ terraspace fmt demo -t stacke


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

    terraspace fmt stack1
    terraspace fmt module1
    terraspace fmt -h

## Context

closes #95

## How to Test

Run `terraspace fmt STACK` with a stack specified.

## Version Changes

Patch