### PR TITLE
terraspace force-unlock command

### DIFF
--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -85,6 +85,13 @@ module Terraspace
       Down.new(options.merge(mod: mod)).run
     end
 
+    desc "force_unlock", "Calls terrform force-unlock"
+    long_desc Help.text(:force_unlock)
+    instance_option.call
+    def force_unlock(mod, lock_id)
+      Commander.new("force-unlock", options.merge(mod: mod, lock_id: lock_id)).run
+    end
+
     desc "fmt", "Run terraform fmt"
     long_desc Help.text(:fmt)
     type_option.call

--- a/lib/terraspace/cli/help/force_unlock.md
+++ b/lib/terraspace/cli/help/force_unlock.md
@@ -1,0 +1,7 @@
+## Example
+
+    terraspace force_unlock demo ab7f3469-2a5f-07b9-29c5-dec1537ec8b0
+
+Instance option:
+
+    terraspace force_unlock demo -i 2 ab7f3469-2a5f-07b9-29c5-dec1537ec8b0

--- a/lib/terraspace/terraform/args/default.rb
+++ b/lib/terraspace/terraform/args/default.rb
@@ -3,7 +3,7 @@ require "tempfile"
 module Terraspace::Terraform::Args
   class Default
     def initialize(mod, name, options={})
-      @mod, @name, @options = mod, name, options
+      @mod, @name, @options = mod, name.underscore, options
       @quiet = @options[:quiet].nil? ? true : @options[:quiet]
     end
 
@@ -11,12 +11,16 @@ module Terraspace::Terraform::Args
       # https://terraspace.cloud/docs/ci-automation/
       ENV['TF_IN_AUTOMATION'] = '1' if @options[:auto]
 
-      if %w[apply destroy init output plan show].include?(@name)
-        meth = "#{@name}_args"
-        send(meth)
+      args_meth = "#{@name}_args"
+      if respond_to?(args_meth)
+        send(args_meth)
       else
         []
       end
+    end
+
+    def force_unlock_args
+      [" -force #{@options[:lock_id]}"]
     end
 
     def apply_args


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Add command

    terraspace force-unlock

## Context

#58

## How to Test

Run command after canceling a command midstream. 

Note, would like to also better handle the passing of the ctrl-c signal from terraspace to terraform. Can do in another PR.

## Version Changes

Patch