### PR TITLE
fix terraspace all summarized logging

### DIFF
--- a/lib/terraspace/all/runner.rb
+++ b/lib/terraspace/all/runner.rb
@@ -104,7 +104,7 @@ module Terraspace::All
     def run_terraspace(mod_name)
       set_log_path!(mod_name)
       name = command_map(@command)
-      o = @options.merge(mod: mod_name, yes: true, build: false, input: false)
+      o = @options.merge(mod: mod_name, yes: true, build: false, input: false, log_to_stderr: true)
       o.merge!(quiet: false) if @command == "init" # noisy so can filter and summarize output
       case @command
       when "up"


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes `terraspace all` commands so that output is directed to logs and only summary is shown.

## How to Test

Test `terraspace all` commands and verify that only summary shown

## Version Changes

Patch