### PR TITLE
config.build.pass_files with default files use pass strategy

### DIFF
--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -27,6 +27,8 @@ module Terraspace
       config.build.cache_dir = ":CACHE_ROOT/:REGION/:ENV/:BUILD_DIR"
       config.build.cache_root = nil # defaults to /full/path/to/.terraspace-cache
       config.build.clean_cache = nil # defaults to /full/path/to/.terraspace-cache
+      config.build.default_pass_files = ["/files/"]
+      config.build.pass_files = []
       config.bundle = ActiveSupport::OrderedOptions.new
       config.bundle.logger = ts_logger
       config.init = ActiveSupport::OrderedOptions.new

--- a/lib/terraspace/compiler/strategy/mod.rb
+++ b/lib/terraspace/compiler/strategy/mod.rb
@@ -1,14 +1,15 @@
 module Terraspace::Compiler::Strategy
   class Mod < AbstractBase
     def run
-      ext = File.extname(@src_path).sub('.','')
-      klass = strategy_class(ext)
+      klass = strategy_class(@src_path)
       strategy = klass.new(@mod, @src_path) # IE: Terraspace::Compiler::Strategy::Mod::Rb.new
       strategy.run
     end
 
-    def strategy_class(ext)
+    def strategy_class(path)
+      ext = File.extname(path).sub('.','')
       return Mod::Pass if ext.empty? # infinite loop without this
+      return Mod::Pass if Terraspace.pass_file?(path)
       "Terraspace::Compiler::Strategy::Mod::#{ext.camelize}".constantize rescue Mod::Pass
     end
   end

--- a/lib/terraspace/compiler/writer.rb
+++ b/lib/terraspace/compiler/writer.rb
@@ -10,9 +10,15 @@ module Terraspace::Compiler
     end
 
     def dest_path
-      name = @dest_name || @src_path.sub('.rb','.tf.json')
+      name = get_name
       name = basename(name)
       "#{dest_dir}/#{name}"
+    end
+
+    def get_name
+      return @dest_name if @dest_name
+      return @src_path if Terraspace.pass_file?(@src_path)
+      @src_path.sub('.rb','.tf.json')
     end
 
     def dest_dir

--- a/lib/terraspace/core.rb
+++ b/lib/terraspace/core.rb
@@ -51,5 +51,12 @@ module Terraspace
     def logger=(v)
       @@logger = v
     end
+
+    def pass_file?(path)
+      pass_files = config.build.pass_files + config.build.default_pass_files
+      pass_files.uniq.detect do |i|
+        i.is_a?(Regexp) ? path =~ i : path.include?(i)
+      end
+    end
   end
 end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This useful for ruby files used as part of lambda functions.

## How to Test

* Create app/stacks/demo/files/lambda_function.rb
* Run `terraspace build demo`
* Check that the `ls .terraspace-cache/us-west-2/dev/stacks/demo/files/lambda_function.rb`

## Version Changes

Patch