### PR TITLE
provide runner context to terraspace hook

### DIFF
--- a/lib/terraspace/hooks/runner.rb
+++ b/lib/terraspace/hooks/runner.rb
@@ -2,6 +2,17 @@ module Terraspace::Hooks
   class Runner
     include Terraspace::Util
 
+    # exposing mod and hook so terraspace hooks have access to them via runner context. IE:
+    #
+    #     class EnvExporter
+    #       def call(runner)
+    #         puts "runner.hook #{runner.hook}"
+    #       end
+    #     end
+    #
+    # Docs: http://terraspace.cloud/docs/config/hooks/ruby/#method-argument
+    #
+    attr_reader :mod, :hook
     def initialize(mod, hook)
       @mod, @hook = mod, hook
       @execute = @hook["execute"]
@@ -12,11 +23,23 @@ module Terraspace::Hooks
       when String
         Terraspace::Shell.new(@mod, @execute, exit_on_fail: @hook["exit_on_fail"]).run
       when -> (e) { e.respond_to?(:public_instance_methods) && e.public_instance_methods.include?(:call) }
-        @execute.new.call
+        executor = @execute.new
       when -> (e) { e.respond_to?(:call) }
-        @execute.call
+        executor = @execute
       else
         logger.warn "WARN: execute option not set for hook: #{@hook.inspect}"
+      end
+
+      if executor
+        meth = executor.method(:call)
+        case meth.arity
+        when 0
+          executor.call # backwards compatibility
+        when 1
+          executor.call(self)
+        else
+          raise "The #{executor} call method definition has been more than 1 arguments and is not supported"
+        end
       end
     end
   end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Pass the `runner` self argument to the user defined `call` method if it has an arity of 1.

## Context

https://community.boltops.com/t/hooks-and-internal-variables/687

## How to Test

Test example in the docs: http://terraspace.cloud/docs/config/hooks/ruby/#method-argument

## Version Changes

Patch
