### PR TITLE
popen3 deadlock fix

### DIFF
--- a/lib/terraspace/shell.rb
+++ b/lib/terraspace/shell.rb
@@ -29,24 +29,52 @@ module Terraspace
 
     def popen3(env)
       Open3.popen3(env, @command, chdir: @mod.cache_dir) do |stdin, stdout, stderr, wait_thread|
-        mimic_terraform_input(stdin, stdout)
-        while out = stdout.gets
-          terraform_to_stdout(out)
-        end
-
-        while err = stderr.gets
-          @error ||= Error.new
-          @error.lines << err # aggregate all error lines
-          unless @error.known?
-            # Sometimes may print a "\e[31m\n" which like during dependencies fetcher init
-            # suppress it so dont get a bunch of annoying "newlines"
-            next if err == "\e[31m\n" && @options[:suppress_error_color]
-            logger.error(err)
-          end
-        end
-
+        handle_streams(stdin, stdout, stderr)
         status = wait_thread.value.exitstatus
         exit_status(status)
+      end
+    end
+
+    BLOCK_SIZE = Integer(ENV['TS_BUFFER_BLOCK_SIZE'] || 102400)
+    BUFFER_TIMEOUT = Integer(ENV['TS_BUFFER_TIMEOUT'] || 3600) # 3600s = 1h
+    def handle_streams(stdin, stdout, stderr)
+      files = [stdout, stderr]
+      # note: t=0 and t=nil means no timeout. See: https://bit.ly/2PURlCX
+      t = BUFFER_TIMEOUT.to_i unless BUFFER_TIMEOUT.nil?
+      Timeout::timeout(t) do
+        until all_eof?(files) do
+          ready = IO.select(files, nil, nil, 0.1)
+          next unless ready
+
+          readable = ready[0]
+          readable.each do |f|
+            buffer = f.read_nonblock(BLOCK_SIZE, exception: false)
+            next unless buffer
+
+            terraform_to_stdout(buffer)
+            handle_input(stdin, buffer)
+          end
+        end
+      end
+    end
+
+    def all_eof?(files)
+      files.find { |f| !f.eof }.nil?
+    end
+
+    # Terraform doesnt seem to stream the line that prompts with "Enter a value:" when using Open3.popen3
+    # Hack around it by mimicking the "Enter a value:" prompt
+    #
+    # Note: system does stream the prompt but using Open3.popen3 so we can capture output to save to logs.
+    def handle_input(stdin, buffer)
+      # stdout doesnt seem to flush and show "Enter a value: " look for earlier output
+      patterns = [
+        "Only 'yes' will be accepted", # prompt for apply. can happen on apply
+        "\e[0m\e[1mvar.", # prompts for variable input. can happen on plan or apply. looking for bold marker also in case "var." shows up somewhere else
+      ]
+      if patterns.any? { |pattern| line.include?(pattern) }
+        print "\n  Enter a value: ".bright
+        stdin.write_nonblock($stdin.gets)
       end
     end
 
@@ -62,37 +90,18 @@ module Terraspace
       end
     end
 
-    # Terraform doesnt seem to stream the line that prompts with "Enter a value:" when using Open3.popen3
-    # Hack around it by mimicking the "Enter a value:" prompt
-    #
-    # Note: system does stream the prompt but using Open3.popen3 so we can capture output to save to logs.
-    def mimic_terraform_input(stdin, stdout)
-      shown = false
-      patterns = [
-        "Only 'yes' will be accepted", # prompt for apply. can happen on apply
-        "\e[0m\e[1mvar.", # prompts for variable input. can happen on plan or apply. looking for bold marker also in case "var." shows up somewhere else
-      ]
-      while out = stdout.gets
-        terraform_to_stdout(out) unless shown && out.include?("Enter a value:")
-        shown = false if out.include?("Enter a value:") # reset shown in case of multiple input prompts
+    def terraform_to_stdout(buffer)
+      prompted = buffer.include?('Enter a value')
+      @prompt_shown ||= prompted
+      return if @prompt_shown && prompted
 
-        # Sometimes stdout doesnt flush and show "Enter a value: ", so mimic it
-        if patterns.any? { |pattern| out.include?(pattern) }
-          print "  Enter a value: ".bright
-          shown = true
-          stdin.write_nonblock($stdin.gets)
-        end
-      end
-    end
-
-    # Allows piping to jq. IE:
-    #   terraspace show demo --json | jq
-    def terraform_to_stdout(out)
-      # so terraform output goes stdout
+      # Terraspace logger has special stdout method so original terraform output
+      # can be piped to jq. IE:
+      #   terraspace show demo --json | jq
       if logger.respond_to?(:stdout) && !@options[:log_to_stderr]
-        logger.stdout(out)
+        logger.stdout(buffer)
       else
-        logger.info(out)
+        logger.info(buffer)
       end
     end
   end


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Terraspace hangs when `TF_LOG=TRACE` is set. This is because `TF_LOG=TRACE` logs so much data that the `Open3.popen3` buffer gets full and the process deadlocks.

See: https://apidock.com/ruby/Open3/popen3

> You should be careful to avoid deadlocks. Since pipes are fixed length buffers, Open3.popen3(“prog”) {|i, o, e, t| o.read } deadlocks if the program generates too much output on stderr. You should read stdout and stderr simultaneously (using threads or IO.select). However, if you don’t need stderr output, you can use Open3.popen2. If merged stdout and stderr output is not a problem, you can use Open3.popen2e. If you really need stdout and stderr output as separate strings, you can consider Open3.capture3.

## Context

* https://github.com/boltops-tools/terraspace/issues/97
* Debug Harness Repo: https://github.com/tongueroo/debug-popen-hang

## How to Test

Run:

    TF_LOG=TRACE terraspace all up -y

Should expect terraspace to finish without hanging.

## Version Changes

Patch
