### PR TITLE
Argv

### DIFF
--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -189,7 +189,6 @@ module Terraspace
 
     desc "state SUBCOMMAND STACK", "Run state."
     long_desc Help.text(:state)
-    option :out, desc: "state pull only. where to write the output to"
     def state(subcommand, mod, *rest)
       State.new(options.merge(subcommand: subcommand, mod: mod, rest: rest)).run
     end

--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -189,6 +189,7 @@ module Terraspace
 
     desc "state SUBCOMMAND STACK", "Run state."
     long_desc Help.text(:state)
+    option :out, desc: "state pull only. where to write the output to"
     def state(subcommand, mod)
       State.new(options.merge(subcommand: subcommand, mod: mod)).run
     end

--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -190,8 +190,8 @@ module Terraspace
     desc "state SUBCOMMAND STACK", "Run state."
     long_desc Help.text(:state)
     option :out, desc: "state pull only. where to write the output to"
-    def state(subcommand, mod)
-      State.new(options.merge(subcommand: subcommand, mod: mod)).run
+    def state(subcommand, mod, *rest)
+      State.new(options.merge(subcommand: subcommand, mod: mod, rest: rest)).run
     end
 
     desc "test", "Run test."

--- a/lib/terraspace/cli/check_setup.rb
+++ b/lib/terraspace/cli/check_setup.rb
@@ -35,7 +35,7 @@ class Terraspace::CLI
     end
 
     def check_command?
-      ARGV[0] == "check_setup"
+      Terraspace.argv[0] == "check_setup"
     end
 
     def terraform_is_not_installed

--- a/lib/terraspace/cli/help/state.md
+++ b/lib/terraspace/cli/help/state.md
@@ -1,0 +1,30 @@
+## Examples
+
+    terraspace state list demo
+    terraspace state mv demo
+    terraspace state pull demo
+    terraspace state push demo
+    terraspace state replace demo
+    terraspace state rm demo
+    terraspace state show demo
+
+## Args Straight Delegation
+
+The `terraspace state` command delegates to the `terraform state` commands passing the arguments straight through. Refer to the underlying `terraform` command help for arguments.  Example:
+
+    terraform state list -h
+    ...
+    Options:
+    ...
+    -id=ID              Filters the results to include only instances whose
+                          resource types have an attribute named "id" whose value
+                          equals the given id string.
+
+This means we can use the `-id` or `--id` option and terraspace will pass it straight through. Example:
+
+    terraspace state list demo --id enabled-bull
+    Building .terraspace-cache/us-west-2/dev/stacks/demo
+    Built in .terraspace-cache/us-west-2/dev/stacks/demo
+    Current directory: .terraspace-cache/us-west-2/dev/stacks/demo
+    => terraform state list --id enabled-bull
+    random_pet.this

--- a/lib/terraspace/cli/init.rb
+++ b/lib/terraspace/cli/init.rb
@@ -98,7 +98,7 @@ class Terraspace::CLI
 
     # only top level command considered
     def calling_command
-      ARGV[0]
+      Terraspace.argv[0]
     end
   end
 end

--- a/lib/terraspace/command.rb
+++ b/lib/terraspace/command.rb
@@ -56,6 +56,9 @@ module Terraspace
           args = ["version"]
         end
 
+        # Terraspace.argv provides consistency when terraspace is being called by rspec-terrspace test harness
+        Terraspace.argv = args.clone # important to clone since Thor removes the first argv
+
         super
       end
 

--- a/lib/terraspace/compiler/commands_concern.rb
+++ b/lib/terraspace/compiler/commands_concern.rb
@@ -11,8 +11,8 @@ module Terraspace::Compiler
     def command_is?(*commands)
       commands.flatten!
       commands.map!(&:to_s)
-      commands.include?(ARGV[0]) ||                  # IE: terraspace up
-      ARGV[0] == "all" && commands.include?(ARGV[1]) # IE: terraspace all up
+      commands.include?(Terraspace.argv[0]) ||                  # IE: terraspace up
+      Terraspace.argv[0] == "all" && commands.include?(Terraspace.argv[1]) # IE: terraspace all up
     end
   end
 end

--- a/lib/terraspace/compiler/dsl/syntax/helpers/common.rb
+++ b/lib/terraspace/compiler/dsl/syntax/helpers/common.rb
@@ -19,7 +19,7 @@ module Terraspace::Compiler::Dsl::Syntax::Helpers
     #     terraspace_command('-') => "terraspace-up-demo"
     #
     def terraspace_command(separator=' ')
-      args = ARGV[0..1] || []
+      args = Terraspace.argv[0..1] || []
       command = ["terraspace"] + args
       command.join(separator)
     end

--- a/lib/terraspace/core.rb
+++ b/lib/terraspace/core.rb
@@ -58,5 +58,15 @@ module Terraspace
         i.is_a?(Regexp) ? path =~ i : path.include?(i)
       end
     end
+
+    # Terraspace.argv provides consistency when terraspace is being called by rspec-terrspace test harness
+    # So use Terraspace.argv instead of ARGV constant
+    def argv=(argv)
+      @@argv = argv
+    end
+
+    def argv
+      @@argv
+    end
   end
 end

--- a/lib/terraspace/terraform/args/default.rb
+++ b/lib/terraspace/terraform/args/default.rb
@@ -11,7 +11,7 @@ module Terraspace::Terraform::Args
       # https://terraspace.cloud/docs/ci-automation/
       ENV['TF_IN_AUTOMATION'] = '1' if @options[:auto]
 
-      args_meth = "#{@name}_args"
+      args_meth = "#{@name}_args".gsub(' ', '_')
       if respond_to?(args_meth)
         send(args_meth)
       else
@@ -101,6 +101,12 @@ module Terraspace::Terraform::Args
 
     def destroy_args
       auto_approve_arg
+    end
+
+    def state_pull_args
+      args = []
+      args << " > #{@options[:out]}" if @options[:out]
+      args
     end
 
     def auto_approve_arg

--- a/lib/terraspace/terraform/args/default.rb
+++ b/lib/terraspace/terraform/args/default.rb
@@ -11,12 +11,24 @@ module Terraspace::Terraform::Args
       # https://terraspace.cloud/docs/ci-automation/
       ENV['TF_IN_AUTOMATION'] = '1' if @options[:auto]
 
-      args_meth = "#{@name}_args".gsub(' ', '_')
-      if respond_to?(args_meth)
-        send(args_meth)
-      else
-        []
+      args = []
+
+      if straight_delegate_args?
+        args += @options[:rest]
+        args.flatten!
       end
+
+      args_meth = "#{@name}_args".gsub(' ', '_') # IE: apply_args, init_args, state_pull_args
+      if respond_to?(args_meth)
+        args += send(args_meth)
+      end
+
+      args
+    end
+
+    # delegate args straight through for special commands, currently state seems to be the only case
+    def straight_delegate_args?
+      @name.include?("state") # IE: "state list", "state pull", "state show"
     end
 
     def force_unlock_args

--- a/lib/terraspace/terraform/args/default.rb
+++ b/lib/terraspace/terraform/args/default.rb
@@ -18,7 +18,7 @@ module Terraspace::Terraform::Args
         args.flatten!
       end
 
-      args_meth = "#{@name}_args".gsub(' ', '_') # IE: apply_args, init_args, state_pull_args
+      args_meth = "#{@name}_args".gsub(' ', '_') # IE: apply_args, init_args
       if respond_to?(args_meth)
         args += send(args_meth)
       end
@@ -113,12 +113,6 @@ module Terraspace::Terraform::Args
 
     def destroy_args
       auto_approve_arg
-    end
-
-    def state_pull_args
-      args = []
-      args << " > #{@options[:out]}" if @options[:out]
-      args
     end
 
     def auto_approve_arg

--- a/terraspace.gemspec
+++ b/terraspace.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "terraspace_plugin_aws", "~> 0.3.0"
   spec.add_dependency "terraspace_plugin_azurerm", "~> 0.3.0"
   spec.add_dependency "terraspace_plugin_google", "~> 0.3.0"
-  spec.add_dependency "rspec-terraspace", "~> 0.2.0"
+  spec.add_dependency "rspec-terraspace", "~> 0.3.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* improve state command: delegate args straight through to underlying terraform commands
* improve args setting. leverage by rspec-terraspace for consistent checking
* improve help: can call help regardless of being a terraspace project no matter what 

## Context

https://github.com/boltops-tools/rspec-terraspace/pull/5

## How to Test

Sanity check that terraspace new project works.

## Version Changes

Patch