### PR TITLE
use Dir.glob(expr, File::FNM_DOTMATCH) so dotfiles are copied, allowing .terraform-version for tfenv

### DIFF
--- a/lib/terraspace/compiler/builder.rb
+++ b/lib/terraspace/compiler/builder.rb
@@ -37,7 +37,7 @@ module Terraspace::Compiler
 
     def build_config_terraform
       expr = "#{Terraspace.root}/config/terraform/**/*"
-      Dir.glob(expr).each do |path|
+      search(expr).each do |path|
         next unless File.file?(path)
         next if path.include?('config/terraform/tfvars')
         build_config_file(basename(path))
@@ -45,13 +45,13 @@ module Terraspace::Compiler
     end
 
     def build_config_file(file)
-      existing = Dir.glob("#{@mod.root}/#{file}").first
+      existing = search("#{@mod.root}/#{file}").first
       return if existing && existing.ends_with?(".tf") # do not overwrite existing backend.tf, provider.tf, etc
 
       if file.ends_with?(".rb")
-        src_path = Dir.glob("#{@mod.root}/#{basename(file)}").first # existing source. IE: backend.rb in module folder
+        src_path = search("#{@mod.root}/#{basename(file)}").first # existing source. IE: backend.rb in module folder
       end
-      src_path ||= Dir.glob("#{Terraspace.root}/config/terraform/#{file}").first
+      src_path ||= search("#{Terraspace.root}/config/terraform/#{file}").first
       build_mod_file(src_path) if src_path
     end
 
@@ -65,7 +65,7 @@ module Terraspace::Compiler
     end
 
     def with_path(path)
-      Dir.glob(path).each do |src_path|
+      search(path).each do |src_path|
         next if skip?(src_path)
         yield(src_path)
       end
@@ -79,6 +79,10 @@ module Terraspace::Compiler
       src_path.include?("#{@mod.root}/config/hooks") ||
       src_path.include?("#{@mod.root}/test") ||
       src_path.include?("#{@mod.root}/tfvars")
+    end
+
+    def search(expr)
+      Dir.glob(expr, File::FNM_DOTMATCH)
     end
   end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

## Context

Fixes #127

## How to Test

    echo 1.0.3 > app/stacks/demo/.terraspace-version
    terraspace build demo
    cat .terraspace-cache/us-west-2/dev/stacks/demo/.terraform-version 

## Version Changes

Patch