### PR TITLE
Use file not plan for the var-files argument

### DIFF
--- a/lib/terraspace/terraform/args/default.rb
+++ b/lib/terraspace/terraform/args/default.rb
@@ -40,7 +40,7 @@ module Terraspace::Terraform::Args
       var_files = @options[:var_files]
       if var_files
         var_files.each do |file|
-          copy_to_cache(plan)
+          copy_to_cache(file)
         end
         args << var_files.map { |f| "-var-file #{f}" }.join(' ')
       end


### PR DESCRIPTION
This is a 🐞 bug fix.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

A simple typo is changes. `plan` isn't available here, we should be using `file`.

## Version Changes

This is a patch.