### PR TITLE
Fix terraspace output to not add extra newlines

### DIFF
--- a/lib/terraspace/logger.rb
+++ b/lib/terraspace/logger.rb
@@ -21,7 +21,7 @@ module Terraspace
     # Terraspace output goes to stderr by default
     # See: terraspace/shell.rb
     def stdout(msg)
-      puts msg
+      print msg
     end
   end
 end

--- a/lib/terraspace/shell.rb
+++ b/lib/terraspace/shell.rb
@@ -20,11 +20,16 @@ module Terraspace
     def shell
       env = @options[:env] || {}
       env.stringify_keys!
-      if @options[:shell] == "system" # terraspace console
+      if system?
         system(env, @command, chdir: @mod.cache_dir)
       else
         popen3(env)
       end
+    end
+
+    def system?
+      @options[:shell] == "system" || # terraspace console
+      ENV['TS_RUNNER_SYSTEM'] # allow manual override
     end
 
     def popen3(env)
@@ -62,6 +67,7 @@ module Terraspace
             end
           end
         end
+        handle_stdout("\n") # final newline at the end is exactly system behavior
       end
     end
 


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

When there's lots of output from `terraform show`, newlines are added between each stream chunk. This removes the "random" newlines and makes sure that output from `terraspace show` exactly matches `terraform show`.

## Context

#126 

## How to Test

Find a stack that produces rather large output. Compare the `terraspace show` vs `terraform show` output. They should be exactly the same. Example:

    $ terraspace show vpc --json > /tmp/a.json
    Building .terraspace-cache/us-west-2/dev/stacks/vpc
    Built in .terraspace-cache/us-west-2/dev/stacks/vpc
    Current directory: .terraspace-cache/us-west-2/dev/stacks/vpc
    => terraform show -json
    $ cd .terraspace-cache/us-west-2/dev/stacks/vpc ; terraform show -json > /tmp/b.json ; cd -
    $ diff /tmp/a.json /tmp/b.json
    $ 

## Version Changes

Patch