### PR TITLE
fix terraspace output and Enter a value handling

### DIFF
--- a/lib/terraspace/logger.rb
+++ b/lib/terraspace/logger.rb
@@ -20,11 +20,11 @@ module Terraspace
     # Used to allow terraform output to always go to stdout
     # Terraspace output goes to stderr by default
     # See: terraspace/shell.rb
-    def stdout(msg)
-      if msg.size == 8192 && msg[-1] != "\n"
-        print msg
-      else
+    def stdout(msg, newline: true)
+      if newline
         puts msg
+      else
+        print msg
       end
     end
   end

--- a/lib/terraspace/logger.rb
+++ b/lib/terraspace/logger.rb
@@ -21,7 +21,11 @@ module Terraspace
     # Terraspace output goes to stderr by default
     # See: terraspace/shell.rb
     def stdout(msg)
-      print msg
+      if msg.size == 8192 && msg[-1] != "\n"
+        print msg
+      else
+        puts msg
+      end
     end
   end
 end


### PR DESCRIPTION
* Fix terraspace output to not add extra newlines properly
* Handle stdin prompt "Enter a value" properly.
* Seems like handling the extra newlines properly fixes the prompt.

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* Fixes `terraspace output STACK -json | jq` for stacks with really large output properly. Related #139
* Also, improved stdin "Enter a value:" prompt handling. No longer mimic-ing it with Terraspace.

## Context

* #139
* #126

## How to Test

Find a stack that produces rather large output. Compare the `terraspace show` vs `terraform show` output. They should be exactly the same. Example:

    $ terraspace show vpc --json > /tmp/a.json
    Building .terraspace-cache/us-west-2/dev/stacks/vpc
    Built in .terraspace-cache/us-west-2/dev/stacks/vpc
    Current directory: .terraspace-cache/us-west-2/dev/stacks/vpc
    => terraform show -json
    $ cd .terraspace-cache/us-west-2/dev/stacks/vpc ; terraform show -json > /tmp/b.json ; cd -
    $ diff /tmp/a.json /tmp/b.json
    $ 

Also, do a sanity check that `terraspace up` and `terraspace down` work.

## Version Changes

Patch