### PR TITLE
terraspace output: remove extra newline at the end

### DIFF
--- a/lib/terraspace/shell.rb
+++ b/lib/terraspace/shell.rb
@@ -67,7 +67,6 @@ module Terraspace
             end
           end
         end
-        handle_stdout("\n") # final newline at the end is exactly system behavior
       end
     end
 


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

terraspace output: remove extra newline at the end

## Context

* #140 
* #139
* #126

## How to Test

Find a stack that produces rather large output. Compare the `terraspace show` vs `terraform show` output. They should be exactly the same. Example:

    $ terraspace show vpc --json > /tmp/a.json
    Building .terraspace-cache/us-west-2/dev/stacks/vpc
    Built in .terraspace-cache/us-west-2/dev/stacks/vpc
    Current directory: .terraspace-cache/us-west-2/dev/stacks/vpc
    => terraform show -json
    $ cd .terraspace-cache/us-west-2/dev/stacks/vpc ; terraform show -json > /tmp/b.json ; cd -
    $ diff /tmp/a.json /tmp/b.json
    $ 

## Version Changes

Patch