### PR TITLE
improve builder skip check: check if its a dir

### DIFF
--- a/lib/terraspace/compiler/builder.rb
+++ b/lib/terraspace/compiler/builder.rb
@@ -72,13 +72,7 @@ module Terraspace::Compiler
     end
 
     def skip?(src_path)
-      return true unless File.file?(src_path)
-      # certain folders will be skipped
-      src_path.include?("#{@mod.root}/config/args") ||
-      src_path.include?("#{@mod.root}/config/helpers") ||
-      src_path.include?("#{@mod.root}/config/hooks") ||
-      src_path.include?("#{@mod.root}/test") ||
-      src_path.include?("#{@mod.root}/tfvars")
+      Skip.new(@mod, src_path).check?
     end
 
     def search(expr)

--- a/lib/terraspace/compiler/builder/skip.rb
+++ b/lib/terraspace/compiler/builder/skip.rb
@@ -1,0 +1,28 @@
+class Terraspace::Compiler::Builder
+  class Skip
+    def initialize(mod, src_path)
+      @mod, @src_path = mod, src_path
+    end
+
+    def check?
+      return true unless File.file?(@src_path)
+
+      # skip certain folders
+      check_dirs?(
+        "config/args",
+        "config/helpers",
+        "config/hooks",
+        "test",
+        "tfvars",
+      )
+    end
+
+    def check_dirs?(*names)
+      names.flatten.detect { |name| check_dir?(name) }
+    end
+
+    def check_dir?(name)
+      @src_path.include?("#{@mod.root}/#{name}/")
+    end
+  end
+end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Improve the builder skip check. Checks if its a directory by looking for trailing `/`

## Context

Fixes #138

## How to Test

Create a module or stack with `test_something` folder and build it: `terraspace build`. You should see the files in corresponding the `.terraspace-cache` folder.

## Version Changes

Patch