### PR TITLE
improve error message output

### DIFF
--- a/lib/terraspace/shell/error.rb
+++ b/lib/terraspace/shell/error.rb
@@ -2,7 +2,7 @@ class Terraspace::Shell
   class Error
     attr_accessor :lines
     def initialize
-      @lines = '' # holds aggregation of all error lines
+      @lines = [] # holds aggregation of all error lines
     end
 
     def known?
@@ -11,11 +11,11 @@ class Terraspace::Shell
 
     def instance
       if reinit_required?
-        Terraspace::InitRequiredError.new(@lines)
+        Terraspace::InitRequiredError.new(message)
       elsif bucket_not_found?
-        Terraspace::BucketNotFoundError.new(@lines)
+        Terraspace::BucketNotFoundError.new(message)
       elsif shared_cache_error?
-        Terraspace::SharedCacheError.new(@lines)
+        Terraspace::SharedCacheError.new(message)
       end
     end
 
@@ -34,7 +34,8 @@ class Terraspace::Shell
     end
 
     def message
-      @lines.gsub("\n", ' ').squeeze(' ') # remove double whitespaces and newlines
+      # For error messages, terraform lines from buffer do not contain newlines. So join with newline
+      @lines.join("\n")
     end
 
     def shared_cache_error?

--- a/lib/terraspace/terraform/runner/retryer.rb
+++ b/lib/terraspace/terraform/runner/retryer.rb
@@ -9,10 +9,11 @@ class Terraspace::Terraform::Runner
     end
 
     def retry?
-      if @retries <= 3 && !@stop_retrying
+      max_retries = ENV['TS_MAX_RETRIES'] ? ENV['TS_MAX_RETRIES'].to_i : 3
+      if @retries <= max_retries && !@stop_retrying
         true # will retry
       else
-        logger.info "ERROR: #{@exception.message}"
+        logger.info "ERROR after max retries #{max_retries}: #{@exception.message}"
         false # will not retry
       end
     end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Error messages would get concatenated without newlines after max retries. This joins the final error message with newlines properly so it's readable.

Also added `TS_MAX_RETRIES` env variable ability.

## Context

N/A

## How to Test

One way to test is to go from an rather old version of terraform to the latest. If you have already ran `terraspace up` before, the state file structure is old enough to reproduce. Then running `terraspace up` with a newer version of Terraform will produce an error about state after terraspace max retries, which is 3. Can reproduce the error faster with:

    TS_MAX_RETRIES=0 terraspace up demo

## Version Changes

Patch