### PR TITLE
Improve shim wrapper generator

### DIFF
--- a/lib/terraspace/cli/new/shim.rb
+++ b/lib/terraspace/cli/new/shim.rb
@@ -18,7 +18,6 @@ class Terraspace::CLI::New
     end
 
     def create
-      return unless File.exist?(".git")
       dest = @path
       template "terraspace", dest
       chmod dest, 0755
@@ -44,6 +43,8 @@ class Terraspace::CLI::New
 
             export PATH=#{dir}:/$PATH
 
+        Also note, the shim wrapper contains starter code. Though it should generally work for most systems,
+        it might require adjustments depending on your system.
       EOL
     end
 


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* generate shim wrapper even when not in git repo
* also add note about starter code

## Context

https://community.boltops.com/t/using-terraspace-with-azure-devops-pipeline/772/2

## How to Test

Cd into a folder that does not contai `.git` folder and run the shim wrapper generator:

    terraspace new shim

## Version Changes

Patch