### PR TITLE
change default fallback mod strategy to Mod::Tf instead of Mod::Pass for ERB support

### DIFF
--- a/lib/terraspace/compiler/strategy/mod.rb
+++ b/lib/terraspace/compiler/strategy/mod.rb
@@ -10,7 +10,8 @@ module Terraspace::Compiler::Strategy
       ext = File.extname(path).sub('.','')
       return Mod::Pass if ext.empty? # infinite loop without this
       return Mod::Pass if Terraspace.pass_file?(path)
-      "Terraspace::Compiler::Strategy::Mod::#{ext.camelize}".constantize rescue Mod::Pass
+      # Fallback to Mod::Tf for all other files. ERB useful for terraform.tfvars
+      "Terraspace::Compiler::Strategy::Mod::#{ext.camelize}".constantize rescue Mod::Tf
     end
   end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Caught this when using a `terraform.tfvars` file in a stack. By default, files should be using the ERB strategy.

## How to Test

Create a `terraform.tfvars` with some ERB in a stack. And then run:

    terraspace build demo


## Version Changes

Patch