### PR TITLE
fix naming typo in cli help

### DIFF
--- a/lib/terraspace/cli/help/init.md
+++ b/lib/terraspace/cli/help/init.md
@@ -1,4 +1,4 @@
-Typically, Terrasapce auto init should handle initialization. You can run init if you need to though.
+Typically, Terraspace auto init should handle initialization. You can run init if you need to though.
 
 ## Example
 


### PR DESCRIPTION
This is a 🧐 documentation change.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [X] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

I found a minor typo (the name of this tool was misspelled). 
I've also found a few of these in the documentation for which I've opened https://github.com/boltops-tools/terraspace-docs/pull/20.

