### PR TITLE
only remove and create log dir if it exists

### DIFF
--- a/lib/terraspace/cli/clean/logs.rb
+++ b/lib/terraspace/cli/clean/logs.rb
@@ -4,7 +4,6 @@ class Terraspace::CLI::Clean
       action = @options[:truncate] ? "truncate" : "remove"
       are_you_sure?(action)
       @options[:truncate] ? truncate : remove
-      logger.info "Logs #{action}d" # IE: Logs truncated or Logs removed
     end
 
     def truncate
@@ -14,6 +13,7 @@ class Terraspace::CLI::Clean
     end
 
     def remove
+      return unless File.exist?(log_root)
       puts "Removing all files in #{pretty_log_root}/" unless @options[:mute]
       FileUtils.rm_rf(log_root)
       FileUtils.mkdir_p(log_root)


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

only remove and create log dir if it exists

## How to Test

Run

    terraspace clean all -y

And make sure that no log folder is created.

## Version Changes

Patch