### PR TITLE
use pass strategy for binary files

### DIFF
--- a/lib/terraspace/compiler/strategy/mod.rb
+++ b/lib/terraspace/compiler/strategy/mod.rb
@@ -1,3 +1,5 @@
+require "open3"
+
 module Terraspace::Compiler::Strategy
   class Mod < AbstractBase
     def run
@@ -9,9 +11,15 @@ module Terraspace::Compiler::Strategy
     def strategy_class(path)
       ext = File.extname(path).sub('.','')
       return Mod::Pass if ext.empty? # infinite loop without this
-      return Mod::Pass if Terraspace.pass_file?(path)
+      return Mod::Pass if Terraspace.pass_file?(path) or !text_file?(path)
       # Fallback to Mod::Tf for all other files. ERB useful for terraform.tfvars
       "Terraspace::Compiler::Strategy::Mod::#{ext.camelize}".constantize rescue Mod::Tf
+    end
+
+    # Thanks: https://stackoverflow.com/questions/2355866/ruby-how-to-determine-if-file-being-read-is-binary-or-text
+    def text_file?(filename)
+      file_type, status = Open3.capture2e("file", filename)
+      status.success? && file_type.include?("text")
     end
   end
 end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

If modules have a binary files like `file.zip` this breaks `terraspace build` since it uses the tf ERB rendering strategy.  Adding binary file detection to use the pass strategy instead.

## How to Test

Test a module that as a binary file. IE: https://registry.terraform.io/modules/terraform-aws-modules/rds/aws/latest

## Version Changes

Patch