### PR TITLE
process terraform.tfvars file with erb, change default processing strategy back to pass

### DIFF
--- a/lib/terraspace/compiler/strategy/mod.rb
+++ b/lib/terraspace/compiler/strategy/mod.rb
@@ -13,7 +13,7 @@ module Terraspace::Compiler::Strategy
       return Mod::Pass if ext.empty? # infinite loop without this
       return Mod::Pass if Terraspace.pass_file?(path) or !text_file?(path)
       # Fallback to Mod::Tf for all other files. ERB useful for terraform.tfvars
-      "Terraspace::Compiler::Strategy::Mod::#{ext.camelize}".constantize rescue Mod::Tf
+      "Terraspace::Compiler::Strategy::Mod::#{ext.camelize}".constantize rescue Mod::Pass
     end
 
     # Thanks: https://stackoverflow.com/questions/2355866/ruby-how-to-determine-if-file-being-read-is-binary-or-text

--- a/lib/terraspace/compiler/strategy/mod/tfvars.rb
+++ b/lib/terraspace/compiler/strategy/mod/tfvars.rb
@@ -1,0 +1,4 @@
+class Terraspace::Compiler::Strategy::Mod
+  class Tfvars < Tf
+  end
+end


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

## Context

* https://github.com/boltops-tools/terraspace/pull/158
* https://github.com/boltops-tools/terraspace/pull/149
* https://community.boltops.com/t/terraform-tfvars-templating-is-not-filled-in/750

## How to Test

Add a `terraform.autovars` file with some ERB in your stack. Run `terraspace build demo`. And confirm that the ERB has been processed.

## Version Changes

Patch