### PR TITLE
expand_string? interface method so plugins can decide whether or not to expand the string

### DIFF
--- a/lib/terraspace/plugin/expander/interface.rb
+++ b/lib/terraspace/plugin/expander/interface.rb
@@ -34,6 +34,7 @@ module Terraspace::Plugin::Expander
     #
     def expansion(string)
       return string unless string.is_a?(String) # in case of nil
+      return string unless expand_string?(string)
 
       string = string.dup
       vars = string.scan(/:\w+/) # => [":ENV", ":BUILD_DIR"]
@@ -41,6 +42,11 @@ module Terraspace::Plugin::Expander
         string.gsub!(var, var_value(var))
       end
       strip(string)
+    end
+
+    # interface method
+    def expand_string?(string)
+      true
     end
 
     # remove leading and trailing common separators.


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Add an `expand_string?` interface method for plugin expanders.

## Context

https://community.boltops.com/t/terraspace-aws-backend-undefined-method/790

## How to Test

Try a ruby DSL backend.rb like so:

backend.rb

```ruby
backend("s3",
  bucket:                      'terraform-state-demo-:ACCOUNT-:REGION-:ENV',
  key:                         ':REGION/:ENV/:BUILD_DIR/terraform.tfstate',
  region:                      ":REGION",
  encrypt:                     true,
  dynamodb_table:              "terraform_locks",
  acl:                         "private",
  kms_key_id:                  "arn:aws:kms:us-west-2:112233445566:key/937e938d-02f7-458c-8f9b-30846afd3bd3",
)
```


## Version Changes

Patch