### PR TITLE
Use Activesupport All

### DIFF
--- a/lib/terraspace.rb
+++ b/lib/terraspace.rb
@@ -5,11 +5,7 @@ $:.unshift(File.expand_path("../", __FILE__))
 require "terraspace/autoloader"
 Terraspace::Autoloader.setup
 
-require "active_support/concern"
-require "active_support/core_ext/class"
-require "active_support/core_ext/hash"
-require "active_support/core_ext/string"
-require "active_support/ordered_options"
+require "active_support/all"
 require "cli-format"
 require "deep_merge/rails_compat"
 require "dsl_evaluator"

--- a/spec/terraspace/seeder/content_spec.rb
+++ b/spec/terraspace/seeder/content_spec.rb
@@ -37,8 +37,8 @@ describe Terraspace::Seeder::Content do
       result = content.build
       expected =<<~EOL
         # Required variables:
-        name    = "string"
-        azs     = [...] # list(string)
+        name      = "string"
+        azs       = [...] # list(string)
 
         # Optional variables:
         # project = "project-name"


### PR DESCRIPTION
* should help prevent issues where activesupport adds new dependencies required when using components separately

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Bummer. Looks like activesupport 7.0 is causing some issues: 

* https://github.com/rails/rails/issues/43851
* https://github.com/Shopify/krane/issues/851

Essentially, a new `IsolatedExecutionState` component needs to be required now.

```ruby
require "active_support/isolated_execution_state"
```

Bug only appears when require activesupport components individually. It's pretty hard for the activesupport developers to account these type of issues as they probably have edge versions of activesupport running. So its pretty understandable. 🤣

Think it's more practical `require "active_support/all"` in terraspace. This mitigates possible future issues generally.

## Context

Related to a few reports:

* https://github.com/boltops-tools/ufo/issues/121
* https://github.com/boltops-tools/terraspace/issues/163#issuecomment-995575381
* https://community.boltops.com/t/encountering-error-with-terraspace-when-run-from-azure-devops-microsoft-agent/796

Appreciate the constructive reports.

## How to Test

This is how it tested. Spun up a new cloud9 machine. Install terraform and terraspace and tested on a fresh environment:

Install tfenv:

    git clone https://github.com/tfutils/tfenv.git ~/.tfenv
    echo 'export PATH="$HOME/.tfenv/bin:$PATH"' >> ~/.bash_profile
    type tfenv
    tfenv install latest
    tfenv use latest
    terraform version

Install ruby 2.7 and use as default    

    ruby -v
    rvm list
    rvm install 2.7.5
    rvm list
    rvm --default use 2.7.5

Install terraspace. Note: configured `~/.gemrc` to speed up the gem installation process.

    cat << EOF > ~/.gemrc
    ---
    :backtrace: false
    :bulk_threshold: 1000
    :sources:
    - https://rubygems.org
    :update_sources: true
    :verbose: true
    benchmark: false
    install: "--no-document"
    update: "--no-document"
    EOF
    gem install terraspace

Deploy terraspace demo s3 bucket example:

    terraspace new project infra --examples
    cd infra/
    terraspace up demo -y
    terraspace down demo -y

## Version Changes

Patch