### PR TITLE
check if file command is installed

### DIFF
--- a/lib/terraspace/compiler/strategy/mod.rb
+++ b/lib/terraspace/compiler/strategy/mod.rb
@@ -1,5 +1,3 @@
-require "open3"
-
 module Terraspace::Compiler::Strategy
   class Mod < AbstractBase
     def run
@@ -16,10 +14,9 @@ module Terraspace::Compiler::Strategy
       "Terraspace::Compiler::Strategy::Mod::#{ext.camelize}".constantize rescue Mod::Pass
     end
 
-    # Thanks: https://stackoverflow.com/questions/2355866/ruby-how-to-determine-if-file-being-read-is-binary-or-text
+  private
     def text_file?(filename)
-      file_type, status = Open3.capture2e("file", filename)
-      status.success? && file_type.include?("text")
+      TextFile.new(filename).check
     end
   end
 end

--- a/lib/terraspace/compiler/strategy/mod/text_file.rb
+++ b/lib/terraspace/compiler/strategy/mod/text_file.rb
@@ -1,0 +1,35 @@
+require "open3"
+
+class Terraspace::Compiler::Strategy::Mod
+  class TextFile
+    include Terraspace::Util::Logging
+
+    def initialize(filename)
+      @filename = filename
+    end
+
+    @@already_reported = false
+    def check
+      unless file_installed?
+        return true if @@already_reported
+        logger.warn <<~EOL.color(:yellow)
+          WARN: The command 'file' is not installed.
+          Unable to check if files are text or binary files as a part of the Terraspace compile processing.
+          Assuming all files are not binary file.
+
+          Please install the file command to remove this warning message.
+        EOL
+        @@already_reported = true
+        return true
+      end
+      # Thanks: https://stackoverflow.com/questions/2355866/ruby-how-to-determine-if-file-being-read-is-binary-or-text
+      file_type, status = Open3.capture2e("file", @filename)
+      status.success? && file_type.include?("text")
+    end
+
+  private
+    def file_installed?
+      system("type file > /dev/null 2>&1")
+    end
+  end
+end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

When the `file` command is not installed, `terraspace build` doesn't work. This is because terraspace checks if files are text or binary files as part of processing them.

This PR provides a warning to the user to install the `file` command. It also allows `terraspace build` to continue working and defaults to assuming that all files are text files, not binary.

## Context

* https://github.com/boltops-tools/terraspace/issues/163

## How to Test

    sudo mv /usr/bin/file{.bak,}
    cd terraspace-project-folder
    terrasapce build demo

Confirm there's a warning:

    $ terraspace build demo
    WARN: The command 'file' is not installed.
    Unable to check if files are text or binary files as a part of the Terraspace compile processing.
    Assuming all files are not binary file.
    
    Please install the file command to remove this warning message.
    Building .terraspace-cache/us-west-2/dev/stacks/demo
    Built in .terraspace-cache/us-west-2/dev/stacks/demo
    $

## Version Changes

Patch