### PR TITLE
add bundler as a dependency

### DIFF
--- a/terraspace.gemspec
+++ b/terraspace.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "activesupport"
+  spec.add_dependency "bundler"
   spec.add_dependency "cli-format"
   spec.add_dependency "deep_merge"
   spec.add_dependency "dsl_evaluator"


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Bundler should be a dependency and installed a part of terraspace.

## Context

Ran into this while looking into:

* https://github.com/boltops-tools/terraspace/issues/163
* https://github.com/boltops-tools/terraspace/pull/165

## How to Test

Sanity check of terraspace by trying out the quick start example on a fresh machine. IE: docker or cloud9, etc

## Version Changes

Patch