### PR TITLE
require active_support properly

### DIFF
--- a/lib/terraspace.rb
+++ b/lib/terraspace.rb
@@ -5,7 +5,12 @@ $:.unshift(File.expand_path("../", __FILE__))
 require "terraspace/autoloader"
 Terraspace::Autoloader.setup
 
-require "active_support/all"
+require "active_support"
+require "active_support/concern"
+require "active_support/core_ext/class"
+require "active_support/core_ext/hash"
+require "active_support/core_ext/string"
+require "active_support/ordered_options"
 require "cli-format"
 require "deep_merge/rails_compat"
 require "dsl_evaluator"


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Turns out I was requiring activesupport incorrectly 🤦🏻‍♂️🤣  

## Context

https://github.com/boltops-tools/terraspace/pull/164

## How to Test

Make sure terraspace doesn't bomb 💣

## Version Changes

Patch