### PR TITLE
fix new plugin generator, use right include Helper

### DIFF
--- a/lib/terraspace/cli/new/plugin.rb
+++ b/lib/terraspace/cli/new/plugin.rb
@@ -1,6 +1,6 @@
 class Terraspace::CLI::New
   class Plugin < Sequence
-    include Helpers
+    include Helper
 
     argument :name
 

--- a/lib/terraspace/cli/new/plugin/helper.rb
+++ b/lib/terraspace/cli/new/plugin/helper.rb
@@ -1,5 +1,5 @@
 class Terraspace::CLI::New::Plugin
-  module Helpers
+  module Helper
   private
     # helper
     def camel_name


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes #73 

   terraspace new plugin myplugin

Note: Fixed it but didn't really check the templates. Mainly only checked that the generator doesn't bomb.

## Context

#73

## How to Test

Run:

   terraspace new plugin myplugin

## Version Changes

Patch