### PR TITLE
remove project --test-structure option in favor of terraspace new test --type project

### DIFF
--- a/lib/terraspace/cli/new/project.rb
+++ b/lib/terraspace/cli/new/project.rb
@@ -6,7 +6,6 @@ class Terraspace::CLI::New
         [:config, type: :boolean, default: true, desc: "Whether or not to generate config files."],
         [:force, aliases: %w[y], type: :boolean, desc: "Bypass overwrite are you sure prompt for existing files."],
         [:quiet, type: :boolean, desc: "Quiet output."],
-        [:test_structure, type: :boolean, desc: "Create project bootstrap test structure."],
       ]
     end
 
@@ -58,11 +57,6 @@ class Terraspace::CLI::New
     def create_starter_stack
       return unless @options[:examples]
       Stack.start(component_args("demo", name))
-    end
-
-    def create_test
-      return unless @options[:test_structure]
-      Test::Bootstrap.start(["--dir", name])
     end
 
     def bundle_install

--- a/lib/terraspace/cli/new/test.rb
+++ b/lib/terraspace/cli/new/test.rb
@@ -3,13 +3,13 @@ class Terraspace::CLI::New
     include Thor::Actions
     include Terraspace::CLI::New::Helpers
 
-    argument :name
+    argument :name, required: false
 
     def self.options
       [
         [:force, aliases: %w[y], type: :boolean, desc: "Bypass overwrite are you sure prompt for existing files"],
         [:test_name, desc: "Test name. Defaults to the project, module or stack name"],
-        [:type, default: "project", desc: "project, stack or module"],
+        [:type, default: "stack", desc: "project, stack or module"],
       ]
     end
     options.each { |args| class_option(*args) }
@@ -42,6 +42,10 @@ class Terraspace::CLI::New
   public
 
     def create
+      if type != 'project' && name.nil?
+        puts "ERROR: require NAME for type stack and module".color(:red)
+        exit 1
+      end
       test_template_source(@options[:lang], type)
       puts "=> Creating #{type} test: #{name}"
       directory ".", dest


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* Remove `--test-structure` option with `terraspace new project`
* Instead use `terraspace new test --type project`

## Context

Fixes #93

## How to Test

    terraspace new project --examples tools
    cd tools
    terraspace new test --type project

## Version Changes

Patch