### PR TITLE
improve cli help: group main commands at top

### DIFF
--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -1,5 +1,7 @@
 module Terraspace
   class CLI < Command
+    include Help
+
     class_option :verbose, type: :boolean
     class_option :noop, type: :boolean
 

--- a/lib/terraspace/cli/help.rb
+++ b/lib/terraspace/cli/help.rb
@@ -1,11 +1,58 @@
 class Terraspace::CLI
-  class Help
-    class << self
-      def text(namespaced_command)
-        path = namespaced_command.to_s.gsub(':','/')
-        path = File.expand_path("../help/#{path}.md", __FILE__)
-        IO.read(path) if File.exist?(path)
+  module Help
+    extend ActiveSupport::Concern
+
+    class_methods do
+      def main_commands
+        %w[
+          all
+          build
+          bundle
+          down
+          list
+          new
+          plan
+          seed
+          up
+        ]
+      end
+
+      def help(shell, subcommand)
+        list = printable_commands(true, subcommand)
+        list.sort! { |a, b| a[0] <=> b[0] }
+        filter = Proc.new do |command, desc|
+          main_commands.detect { |name| command =~ Regexp.new("^terraspace #{name}") }
+        end
+        main = list.select(&filter)
+        other = list.reject(&filter)
+
+        shell.say <<~EOL
+          Usage: terraspace COMMAND [args]
+
+          The available commands are listed below.
+          The primary workflow commands are given first, followed by
+          less common or more advanced commands.
+        EOL
+        shell.say "\nMain Commands:\n\n"
+        shell.print_table(main, :indent => 2, :truncate => true)
+        shell.say "\nOther Commands:\n\n"
+        shell.print_table(other, :indent => 2, :truncate => true)
+        shell.say <<~EOL
+
+          For more help on each command, you can use the -h option. Example:
+
+              terraspace up -h
+
+          CLI Reference also available at: https://terraspace.cloud/reference/
+        EOL
       end
     end
+
+    def text(namespaced_command)
+      path = namespaced_command.to_s.gsub(':','/')
+      path = File.expand_path("../help/#{path}.md", __FILE__)
+      IO.read(path) if File.exist?(path)
+    end
+    extend self
   end
 end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Improve the top-level `terraspace -h` command.  Examples:

    terraspace help
    terraspace --help
    terraspace -h

Example with output:

    $ terraspace -h
    Usage: terraspace COMMAND [args]
    
    The available commands are listed below.
    The primary workflow commands are given first, followed by
    less common or more advanced commands.
    
    Main Commands:
    
      terraspace all SUBCOMMAND  # all subcommands
      terraspace build [STACK]   # Build project.
      terraspace bundle          # Bundle with Terrafile.
      terraspace down STACK      # Destroy infrastructure stack.
      terraspace list            # List stacks and modules.
      terraspace new SUBCOMMAND  # new subcommands
      terraspace plan STACK      # Plan stack.
      terraspace seed STACK      # Build starer seed tfvars file.
      terraspace up STACK        # Deploy infrastructure stack.
    
    Other Commands:
    
      terraspace check_setup             # Check setup.
      terraspace clean SUBCOMMAND        # clean subcommands
      terraspace completion *PARAMS      # Prints words for auto-completion.
      terraspace completion_script       # Generates a script that can be eval to setup auto-completion.
      terraspace console STACK           # Run console in built terraform project.
      terraspace fmt                     # Run terraform fmt
      terraspace force_unlock            # Calls terrform force-unlock
      terraspace help [COMMAND]          # Describe available commands or one specific command
      terraspace info STACK              # Get info about stack.
      terraspace init STACK              # Run init in built terraform project.
      terraspace logs [ACTION] [STACK]   # View and tail logs.
      terraspace output STACK            # Run output.
      terraspace providers STACK         # Show providers.
      terraspace refresh STACK           # Run refresh.
      terraspace show STACK              # Run show.
      terraspace state SUBCOMMAND STACK  # Run state.
      terraspace summary                 # Summarize resources.
      terraspace test                    # Run test.
      terraspace tfc SUBCOMMAND          # tfc subcommands
      terraspace validate STACK          # Validate stack.
      terraspace version                 # Prints version.
    
    For more help on each command, you can use the -h option. Example:
    
        terraspace up -h
    
    CLI Reference also available at: https://terraspace.cloud/reference/
    $

## How to Test

    terraspace -h

## Version Changes

Patch