### PR TITLE
better wrap and pass through terraform args

### DIFF
--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -1,15 +1,12 @@
 module Terraspace
   class CLI < Command
-    include Help
+    include Concern
 
     class_option :verbose, type: :boolean
     class_option :noop, type: :boolean
 
     yes_option = Proc.new {
       option :yes, aliases: :y, type: :boolean, desc: "-auto-approve the terraform apply"
-    }
-    format_option = Proc.new {
-      option :format, desc: "output formats: json, text"
     }
     out_option = Proc.new {
       option :out, aliases: :o, desc: "Write the output to path"
@@ -73,8 +70,8 @@ module Terraspace
     desc "console STACK", "Run console in built terraform project."
     long_desc Help.text(:console)
     instance_option.call
-    def console(mod)
-      Commander.new("console", options.merge(mod: mod, shell: "system")).run
+    def console(mod, *args)
+      Commander.new("console", options.merge(mod: mod, args: args, shell: "system")).run
     end
 
     desc "down STACK", "Destroy infrastructure stack."
@@ -83,8 +80,8 @@ module Terraspace
     yes_option.call
     reconfigure_option.call
     option :destroy_workspace, type: :boolean, desc: "Also destroy the Cloud workspace. Only applies when using Terraform Cloud remote backend."
-    def down(mod)
-      Down.new(options.merge(mod: mod)).run
+    def down(mod, *args)
+      Down.new(options.merge(mod: mod, args: args)).run
     end
 
     desc "force_unlock", "Calls terrform force-unlock"
@@ -113,8 +110,8 @@ module Terraspace
     desc "init STACK", "Run init in built terraform project."
     long_desc Help.text(:init)
     instance_option.call
-    def init(mod)
-      Commander.new("init", options.merge(mod: mod, quiet: false)).run
+    def init(mod, *args)
+      Commander.new("init", options.merge(mod: mod, args: args, quiet: false)).run
     end
 
     desc "list", "List stacks and modules."
@@ -143,22 +140,22 @@ module Terraspace
     out_option.call
     reconfigure_option.call
     option :copy_to_root, type: :boolean, default: true, desc: "Copy plan file generated in the cache folder back to project root"
-    def plan(mod)
-      Commander.new("plan", options.merge(mod: mod)).run
+    def plan(mod, *args)
+      Commander.new("plan", options.merge(mod: mod, args: args)).run
     end
 
     desc "providers STACK", "Show providers."
     long_desc Help.text(:providers)
     instance_option.call
-    def providers(mod)
-      Commander.new("providers", options.merge(mod: mod)).run
+    def providers(mod, *args)
+      Commander.new("providers", options.merge(mod: mod, args: args)).run
     end
 
     desc "refresh STACK", "Run refresh."
     long_desc Help.text(:refresh)
     instance_option.call
-    def refresh(mod)
-      Commander.new("refresh", options.merge(mod: mod)).run
+    def refresh(mod, *args)
+      Commander.new("refresh", options.merge(mod: mod, args: args)).run
     end
 
     desc "seed STACK", "Build starer seed tfvars file."
@@ -184,9 +181,8 @@ module Terraspace
     long_desc Help.text(:show)
     instance_option.call
     option :plan, desc: "path to created.plan"
-    option :json, type: :boolean, desc: "show plan in json format"
-    def show(mod)
-      Commander.new("show", options.merge(mod: mod)).run
+    def show(mod, *args)
+      Commander.new("show", options.merge(mod: mod, args: args)).run
     end
 
     desc "state SUBCOMMAND STACK", "Run state."
@@ -203,11 +199,10 @@ module Terraspace
 
     desc "output STACK", "Run output."
     long_desc Help.text(:output)
-    format_option.call
     instance_option.call
     out_option.call
-    def output(mod)
-      Commander.new("output", options.merge(mod: mod)).run
+    def output(mod, *args)
+      Commander.new("output", options.merge(mod: mod, args: args)).run
     end
 
     desc "up STACK", "Deploy infrastructure stack."
@@ -220,15 +215,15 @@ module Terraspace
     reconfigure_option.call
     option :plan, desc: "Execution plan that can be used to only execute a pre-determined set of actions."
     option :var_files, type: :array, desc: "list of var files"
-    def up(mod)
-      Up.new(options.merge(mod: mod)).run
+    def up(mod, *args)
+      Up.new(options.merge(mod: mod, args: args)).run
     end
 
     desc "validate STACK", "Validate stack."
     long_desc Help.text(:validate)
     instance_option.call
-    def validate(mod)
-      Commander.new("validate", options.merge(mod: mod)).run
+    def validate(mod, *args)
+      Commander.new("validate", options.merge(mod: mod, args: args)).run
     end
 
     desc "completion *PARAMS", "Prints words for auto-completion."

--- a/lib/terraspace/cli/concern.rb
+++ b/lib/terraspace/cli/concern.rb
@@ -1,0 +1,111 @@
+class Terraspace::CLI
+  module Concern
+    extend ActiveSupport::Concern
+
+    class_methods do
+      # So the Thor::Parser::Options#parse allows flag switch shorthand notation. IE:
+      #
+      #    command -abc
+      #
+      # Is same as:
+      #
+      #    command -a -b -c
+      #
+      # This messes up the options like -destroy.
+      #
+      #    terraspace plan -destroy
+      #
+      # Since only a single dash (-) is passed. It's interpreted as a bunch of flag switches.
+      # Providing -- works just fine
+      #
+      #    terraspace plan --destroy
+      #
+      # But it'll be nice if user can use -destroy or --destroy
+      #
+      # Interestingly, -no-color won't be interpreted by Thor as switch flag due to the - inbetween.
+      #
+      # Looked into the Thor code:
+      #
+      #   Thor::Parser::Options#parse https://github.com/rails/thor/blob/5c666b4c25e748e57eec2d529d94c5059030979e/lib/thor/parser/options.rb#L88
+      #   Thor::Parser::Options#current_is_switch? https://github.com/rails/thor/blob/5c666b4c25e748e57eec2d529d94c5059030979e/lib/thor/parser/options.rb#L165
+      #
+      # Overriding the current_is_switch? is dirtier than overriding start
+      # and adjusting the argv before passing to Thor.
+      #
+      # There are only so few Terraform boolean options that are single words. To find (fish shell)
+      #
+      #     for i in init validate plan apply destroy console fmt force-unlock get graph import login logout output providers refresh show state taint test untaint version workspace ; echo "$i:" ; terraform $i -h | grep '^  -' ; end
+      #     for i in init validate plan apply destroy console fmt force-unlock get graph import login logout output providers refresh show state taint test untaint version workspace ; echo "$i:" ; terraform $i -h | grep '^  -' | grep -v =  | sed 's/  -//' | grep -v - | sed -r 's/\s+.*//' | sed 's/^/  /' ; end
+      #     for i in init validate plan apply destroy console fmt force-unlock get graph import login logout output providers refresh show state taint test untaint version workspace ; terraform $i -h | grep '^  -' | grep -v =  | sed 's/  -//' | grep -v - | sed -r 's/\s+.*//' ; end | sort | uniq
+      #
+      def start(argv)
+        single_word_boolean_args = %w[
+          check
+          destroy
+          diff
+          force
+          json
+          raw
+          reconfigure
+          recursive
+          upgrade
+        ]
+        argv.map! do |arg|
+          word = arg.sub(/^-/,'')
+          if single_word_boolean_args.include?(word)
+            # Add double dash (--).
+            # Later in Terraspace::Terraform::Args::Pass#args a single dash (-) is ensured.
+            "--#{word}" # IE: destroy => --destroy
+          else
+            arg
+          end
+        end
+        super(argv)
+      end
+
+      def main_commands
+        %w[
+          all
+          build
+          bundle
+          down
+          list
+          new
+          plan
+          seed
+          up
+        ]
+      end
+
+      def help(shell, subcommand)
+        list = printable_commands(true, subcommand)
+        list.sort! { |a, b| a[0] <=> b[0] }
+        filter = Proc.new do |command, desc|
+          main_commands.detect { |name| command =~ Regexp.new("^terraspace #{name}") }
+        end
+        main = list.select(&filter)
+        other = list.reject(&filter)
+
+        shell.say <<~EOL
+          Usage: terraspace COMMAND [args]
+
+          The available commands are listed below.
+          The primary workflow commands are given first, followed by
+          less common or more advanced commands.
+        EOL
+        shell.say "\nMain Commands:\n\n"
+        shell.print_table(main, indent: 2, truncate: true)
+        shell.say "\nOther Commands:\n\n"
+        shell.print_table(other, indent: 2, truncate: true)
+        shell.say <<~EOL
+
+          For more help on each command, you can use the -h option. Example:
+
+              terraspace up -h
+
+          CLI Reference also available at: https://terraspace.cloud/reference/
+        EOL
+      end
+    end
+  end
+end

--- a/lib/terraspace/cli/help.rb
+++ b/lib/terraspace/cli/help.rb
@@ -1,53 +1,5 @@
 class Terraspace::CLI
   module Help
-    extend ActiveSupport::Concern
-
-    class_methods do
-      def main_commands
-        %w[
-          all
-          build
-          bundle
-          down
-          list
-          new
-          plan
-          seed
-          up
-        ]
-      end
-
-      def help(shell, subcommand)
-        list = printable_commands(true, subcommand)
-        list.sort! { |a, b| a[0] <=> b[0] }
-        filter = Proc.new do |command, desc|
-          main_commands.detect { |name| command =~ Regexp.new("^terraspace #{name}") }
-        end
-        main = list.select(&filter)
-        other = list.reject(&filter)
-
-        shell.say <<~EOL
-          Usage: terraspace COMMAND [args]
-
-          The available commands are listed below.
-          The primary workflow commands are given first, followed by
-          less common or more advanced commands.
-        EOL
-        shell.say "\nMain Commands:\n\n"
-        shell.print_table(main, indent: 2, truncate: true)
-        shell.say "\nOther Commands:\n\n"
-        shell.print_table(other, indent: 2, truncate: true)
-        shell.say <<~EOL
-
-          For more help on each command, you can use the -h option. Example:
-
-              terraspace up -h
-
-          CLI Reference also available at: https://terraspace.cloud/reference/
-        EOL
-      end
-    end
-
     def text(namespaced_command)
       path = namespaced_command.to_s.gsub(':','/')
       path = File.expand_path("../help/#{path}.md", __FILE__)

--- a/lib/terraspace/terraform/args/custom.rb
+++ b/lib/terraspace/terraform/args/custom.rb
@@ -18,21 +18,26 @@ module Terraspace::Terraform::Args
     memoize :build
 
     def args
-      build
-      args = dig("args")
-      args.compact.flatten
-    end
-
-    def var_files
-      build
-      var_files = dig("var_files")
-      var_files.select! { |f| var_file_exist?(f) }
-      var_files.map { |f| "-var-file=#{f}" }
+      terraform_args + var_file_args
     end
 
     def env_vars
       build
       dig("env", {})
+    end
+
+  private
+    def terraform_args
+      build
+      args = dig("args")
+      args.compact.flatten
+    end
+
+    def var_file_args
+      build
+      var_files = dig("var_files")
+      var_files.select! { |f| var_file_exist?(f) }
+      var_files.map { |f| "-var-file=#{f}" }
     end
 
     def var_file_exist?(var_file)

--- a/lib/terraspace/terraform/args/pass.rb
+++ b/lib/terraspace/terraform/args/pass.rb
@@ -1,0 +1,116 @@
+module Terraspace::Terraform::Args
+  class Pass
+    def initialize(mod, name, options={})
+      @mod, @name, @options = mod, name.underscore, options
+    end
+
+    # map to terraform options and only allow valid terraform options
+    # Arg Examples:
+    #   -refresh-only
+    #   -refresh=false
+    #   -var 'foo=bar'
+    def args
+      args = pass_args.select do |arg|
+        arg_name = strip_for_arg_name(arg)
+        arg_type = terraform_arg_types[arg_name]
+        case arg_type
+        when :boolean, :assignment
+          terraform_arg_types.include?(arg_name)
+        when :hash
+          terraform_arg_types.include?(arg_name)
+        end
+      end
+
+      args.map { |arg| "-#{arg}" } # add back in the leading single dash (-)
+    end
+
+  private
+    def pass_args
+      args = (@options[:args] || []).map do |o|
+        o.sub(/^-{1,2}/,'') # strips the - or --
+      end
+      reconstruct_hash_args(args)
+    end
+
+    # Thor parses CLI args -var 'foo=bar'
+    # as:
+    #    ["-var", "foo=bar"]
+    # instead of:
+    #    ["-var 'foo=bar'"]
+    #
+    # So reconstruct it to what works with terraform CLI args
+    def reconstruct_hash_args(args)
+      result = []
+      flatten = []
+      skip = false
+      args.each do |arg|
+        arg_type = terraform_arg_types[arg]
+        if arg_type == :hash || skip
+          skip = true
+          if flatten.size == 1
+            flatten << "'#{arg}'" # surround hash value with single quotes
+          else
+            flatten << arg
+          end
+          if flatten.size == 2 # time to grab value and end skipping
+            result << flatten.join(' ')
+            # reset flags
+            skip = false
+            flatten = []
+          end
+          next if skip
+        else
+          result << arg # boolean (-no-color) or assignment (-refresh=false)
+        end
+      end
+      result
+    end
+
+    # Parses terraform COMMAND -help output for arg types.
+    # Return Example:
+    #
+    #     {
+    #       destroy: :boolean,
+    #       refresh: :assignment,
+    #       var: :hash,
+    #     }
+    #
+    def terraform_arg_types
+      out = terraform_help(@name)
+      lines = out.split("\n")
+      lines.select! do |line|
+        line =~ /^  -/
+      end
+      lines.inject({}) do |result, line|
+        # in:  "  -replace=resource   Force replacement of a particular resource instance using",
+        # out: "-replace=resource   Force replacement of a particular resource instance using",
+        line.sub!('  -', '') # remove leading whitespace and -
+
+        # in:  "  -var 'foo=bar'      Set a value for one of the input variables in the root",
+        # out: "var"
+        # in:  "  -refresh=false      Skip checking for external changes to remote objects",
+        # out: "refresh"
+        arg_name = strip_for_arg_name(line)
+
+        if line.match(/'\w+=\w+'/)  # hash. IE: -var 'foo=bar'
+          result[arg_name] = :hash
+        elsif line.match(/\w+=/)    # value IE: -refresh=false
+          result[arg_name] = :assignment # can include string and numeric values
+        else                        # boolean    IE: -refresh-only
+          result[arg_name] = :boolean
+        end
+        result
+      end
+    end
+
+    def strip_for_arg_name(line)
+      line.sub(/\s+.*/,'').split('=').first # strips the everything except arg name
+    end
+
+    @@terraform_help = {}
+    def terraform_help(name)
+      @@terraform_help[name] ||= `terraform #{name} -help`
+    end
+  end
+end
+

--- a/lib/terraspace/terraform/args/thor.rb
+++ b/lib/terraspace/terraform/args/thor.rb
@@ -1,7 +1,7 @@
 require "tempfile"
 
 module Terraspace::Terraform::Args
-  class Default
+  class Thor
     def initialize(mod, name, options={})
       @mod, @name, @options = mod, name.underscore, options
       @quiet = @options[:quiet].nil? ? true : @options[:quiet]
@@ -81,7 +81,6 @@ module Terraspace::Terraform::Args
 
     def output_args
       args = []
-      args << "-json" if @options[:format] == "json"
       args << "> #{expanded_out}" if @options[:out]
       args
     end
@@ -98,7 +97,6 @@ module Terraspace::Terraform::Args
 
     def show_args
       args = []
-      args << " -json" if @options[:json]
       plan = @options[:plan]
       if plan
         copy_to_cache(@options[:plan])

--- a/lib/terraspace/terraform/runner.rb
+++ b/lib/terraspace/terraform/runner.rb
@@ -16,6 +16,30 @@ module Terraspace::Terraform
       end
     end
 
+    # default at end in case of redirection. IE: terraform output > /path
+    def args
+      args = custom.args + thor.args + pass.args
+      args.uniq
+    end
+
+    # From config/args/terraform.rb https://terraspace.cloud/docs/config/args/terraform/
+    def custom
+      Args::Custom.new(@mod, @name)
+    end
+    memoize :custom
+
+    # From Thor defined/managed cli @options
+    def thor
+      Args::Thor.new(@mod, @name, @options)
+    end
+    memoize :thor
+
+    # From Thor passthrough cli @options[:args]
+    def pass
+      Args::Pass.new(@mod, @name, @options)
+    end
+    memoize :pass
+
     def terraform(name, *args)
       current_dir_message # only show once
 
@@ -57,21 +81,6 @@ module Terraspace::Terraform
       # quiet useful for RemoteState::Fetcher
       @options[:quiet] ? logger.debug(msg) : logger.info(msg)
     end
-
-    def args
-      # base at end in case of redirection. IE: terraform output > /path
-      custom.args + custom.var_files + default.args
-    end
-
-    def custom
-      Args::Custom.new(@mod, @name)
-    end
-    memoize :custom
-
-    def default
-      Args::Default.new(@mod, @name, @options)
-    end
-    memoize :default
 
   private
     def time_took

--- a/spec/terraspace/terraform/args/custom_spec.rb
+++ b/spec/terraspace/terraform/args/custom_spec.rb
@@ -20,10 +20,10 @@ describe Terraspace::Terraform::Args::Custom do
       expect(custom.args).to eq(["-lock-timeout=20m"])
     end
 
-    it "var_files" do
+    it "var_file_args" do
       custom.evaluate_file(file)
       allow(custom).to receive(:var_file_exist?).and_return(true)
-      expect(custom.var_files).to eq(["-var-file=a.tfvars", "-var-file=b.tfvars"])
+      expect(custom.send(:var_file_args)).to eq(["-var-file=a.tfvars", "-var-file=b.tfvars"])
     end
   end
 
@@ -41,10 +41,10 @@ describe Terraspace::Terraform::Args::Custom do
       expect(custom.args).to eq(["-lock-timeout=20m"])
     end
 
-    it "var_files" do
+    it "var_file_args" do
       custom.evaluate_file(file)
       allow(custom).to receive(:var_file_exist?).and_return(true)
-      expect(custom.var_files).to eq([])
+      expect(custom.send(:var_file_args)).to eq([])
     end
   end
 end

--- a/spec/terraspace/terraform/args/pass_spec.rb
+++ b/spec/terraspace/terraform/args/pass_spec.rb
@@ -1,0 +1,101 @@
+describe Terraspace::Terraform::Args::Pass do
+  let(:pass) do
+    described_class.new(mod, name, options)
+  end
+  let(:mod) { double(:mod).as_null_object }
+  let(:options) { {args: args} }
+  # defaults
+  let(:name) { "plan" }
+  let(:args) { [] }
+
+  context "boolean flag" do
+    let(:args) { ["-refresh-only"] }
+    it "pass through args" do
+      args = pass.args
+      expect(args).to eq ["-refresh-only"]
+    end
+  end
+
+  context "assignment arg" do
+    context "-refresh=false" do
+      let(:args) { ["-refresh=false"] }
+      it "pass through args" do
+        args = pass.args
+        expect(args).to eq ["-refresh=false"]
+      end
+    end
+
+    context "-lock-timeout=5s" do
+      let(:args) { ["-lock-timeout=5s"] }
+      it "pass through args" do
+        args = pass.args
+        expect(args).to eq ["-lock-timeout=5s"]
+      end
+    end
+
+    context "-var-file=filename -lock-timeout=5s" do
+      let(:args) { ["-var-file=filename', '-lock-timeout=5s"] }
+      it "pass through args" do
+        args = pass.args
+        expect(args).to eq ["-var-file=filename', '-lock-timeout=5s"]
+      end
+    end
+
+    # normalizes -- to -
+    context "--var-file=filename --lock-timeout=5s" do
+      let(:args) { ["--var-file=filename", "--lock-timeout=5s"] }
+      it "pass through args" do
+        args = pass.args
+        expect(args).to eq ["-var-file=filename", "-lock-timeout=5s"]
+      end
+    end
+  end
+
+  context "hash arg" do
+    context "-var 'foo=bar'" do
+      let(:args) { ["-var 'foo=bar'"] }
+      it "pass through args" do
+        args = pass.args
+        expect(args).to eq ["-var 'foo=bar'"]
+      end
+    end
+
+    context "['-var', 'foo=bar'] improperly passed due to Thor CLI parsing" do
+      let(:args) { ["-var", "foo=bar"] }
+      it "reconstruct to work with terraform cli" do
+        args = pass.send(:pass_args)
+        expect(args).to eq ["var 'foo=bar'"]
+      end
+    end
+  end
+
+  # Works at the parsing level. Also works at Thor CLI parsing level. To test:
+  #
+  #     terraspace plan demo -refresh=false -no-color -var 'foo=bar' -var 'foo2=bar2'
+  #
+  # Results in:
+  #
+  #     terraform plan -input=false -refresh=false -no-color -var 'foo=bar' -var 'foo2=bar2'
+  #
+  context "multiple hash arg" do
+    context "-var 'foo=bar' -var 'foo2=bar2'" do
+      let(:args) { ["-var 'foo=bar'", "-var 'foo2=bar2'"] }
+      it "pass through args" do
+        args = pass.args
+        expect(args).to eq ["-var 'foo=bar'", "-var 'foo2=bar2'"]
+      end
+    end
+  end
+
+  # Could mock out Pass#terraform_help with fixtures,
+  # but will call out to terraform in specs so to see breakage more quickly.
+  context "terraform_arg_types" do
+    it "parses help output to determine arg types" do
+      args = pass.send(:terraform_arg_types)
+      # checking specific keys so spec is more robust to terraform cli changes
+      expect(args['destroy']).to eq(:boolean)
+      expect(args['refresh']).to eq(:assignment)
+      expect(args['var']).to eq(:hash)
+    end
+  end
+end


### PR DESCRIPTION
* pass through unmanaged options to terraform command
* options can be passed with single or double dash
* reconstruct_hash_args when needed for key value based args

This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Improve passing of cli args from terraspace to terraform. Taking a generalized pass-through approach now. There are 3 types of args passing from terraspace to terraform.

1. custom - from https://terraspace.cloud/docs/config/args/
2. terraspace/thor cli options - specific cli options from terraspace and can be handled specially by terraspace before passing onto the underlying terraform command
3. pass-through cli options - pass-through options get passed from terraspace to terraform. In this case, terraspace acts as  wrapper to terraform. There's some smarter handling though. Details below.

### Pass-Through CLI Options Smarter Handling

Both `--` and `-` args work from the terraspace cli interface. Examples:

    terraspace plan demo -refresh=false
    terraspace plan demo --refresh=false
    terraspace plan demo -refresh=false -no-color
    terraspace plan demo -refresh=false --no-color

The final terraform commands will use the single dash (-) option.

Additionally, the underlying `terraform command -h` is called to see that the cli option is valid for that particular install of terraform. The args are only added if it's supported. Otherwise, it will be discarded. This allows terraspace cli commands which call multiple terraform commands like `terraform init` and `terraform apply` in one-go to be passed both cli options and terraspace will figure it out.

## Context

Folks have asked to be able to use underlying args before. Was able to figure it out this go-around.

## How to Test

Tested a lot of commands. Here are examples:

Plan:

    terraspace plan demo -refresh=false
    terraspace plan demo -refresh=false --no-color --destroy --foo --var foo=bar
    terraspace plan demo -refresh=false --no-color --destroy --foo --var foo=bar --lock-timeout=0s
    terraspace plan demo -refresh=false --no-color --destroy --foo -var foo=bar --lock-timeout=0s
    terraspace plan demo -refresh=false -no-color
    terraspace plan demo -refresh=false -no-color --destroy
    terraspace plan demo -refresh=false -no-color --destroy --foo
    terraspace plan demo -refresh=false -no-color --destroy --foo --var foo=bar
    terraspace plan demo -refresh=false -no-color --destroy --foo -var foo=bar --lock-timeout=0s
    terraspace plan demo -refresh=false -no-color --destroy -foo
    terraspace plan demo -refresh=false -no-color --out=foo.plan
    terraspace plan demo -refresh=false -no-color --parallelism=5
    terraspace plan demo -refresh=false -no-color --whatever=true
    terraspace plan demo -refresh=false -no-color -destroy
    terraspace plan demo -refresh=false -no-color -destroy --foo -var foo=bar --lock-timeout=0s
    terraspace plan demo -refresh=false -no-color -destroy -foo
    terraspace plan demo -refresh=false -no-color -var 'foo=bar'
    terraspace plan demo -refresh=false -no-color -var 'foo=bar' -var 'foo2=bar2'
    terraspace plan demo -refresh=false -var 'foo=bar'
    terraspace plan demo -refresh=false -var 'foo=bar' -destroy

Init:

    terraspace init demo -upgrade
    terraspace init demo --upgrade
    terraspace init demo -reconfigure
    terraspace init demo --reconfigure

Force unlock:

    terraspace force_unlock
    terraspace force_unlock demo 1637885224763097

Output:

    terraspace output demo --format json
    terraspace output demo --json
    terraspace output demo -json

Show:

    terraspace show demo --json
    terraspace show demo --json | jq
    terraspace show demo -json
    terraspace show demo -json | jq

Init:

    terraspace init demo --reconfigure --get=false
    terraspace init demo --reconfigure -get=false

Validate:

    terraspace validate demo
    terraspace validate demo -json
    terraspace validate demo -json | jq
    terraspace validate demo -json -no-color
    terraspace validate demo -json -no-color | jq

Down:

    terraspace down demo -y

State:

    terraspace state -h
    terraspace state list demo
    terraspace state list demo --id bucket-concrete-lemming

Up:

    terraspace up demo -compact-warnings
    terraspace up demo -compact-warnings -y

## Version Changes

Minor
