### PR TITLE
remove terraspace_plugin_* gem dependencies out of core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,9 @@ source "https://rubygems.org"
 
 # Specify your gem dependencies in terraspace.gemspec
 gemspec
+
+group :test do
+  gem "terraspace_plugin_aws"
+  gem "terraspace_plugin_azurerm"
+  gem "terraspace_plugin_google"
+end

--- a/lib/terraspace/cli/new/project.rb
+++ b/lib/terraspace/cli/new/project.rb
@@ -27,6 +27,16 @@ class Terraspace::CLI::New
       directory ".", "#{name}"
     end
 
+    def bundle_install
+      return if @options[:bundle] == false
+      log "=> Installing dependencies with: bundle install"
+      Bundler.with_unbundled_env do
+        bundle = "BUNDLE_IGNORE_CONFIG=1 bundle install"
+        bundle << " > /dev/null 2>&1" if @options[:quiet]
+        system(bundle, chdir: name)
+      end
+    end
+
     # Will generate config folder from
     #
     #     1. terraspace code lang templates or
@@ -57,16 +67,6 @@ class Terraspace::CLI::New
     def create_starter_stack
       return unless @options[:examples]
       Stack.start(component_args("demo", name))
-    end
-
-    def bundle_install
-      return if @options[:bundle] == false
-      log "=> Installing dependencies with: bundle install"
-      Bundler.with_unbundled_env do
-        bundle = "BUNDLE_IGNORE_CONFIG=1 bundle install"
-        bundle << " > /dev/null 2>&1" if @options[:quiet]
-        system(bundle, chdir: name)
-      end
     end
 
     def welcome_message_examples

--- a/lib/terraspace/cli/new/source/core.rb
+++ b/lib/terraspace/cli/new/source/core.rb
@@ -19,6 +19,8 @@ module Terraspace::CLI::New::Source
 
     def require_gem(name)
       begin
+        # Need to clear gem paths since installing plugins like terraspace_plugin_aws as part of terraspace new project
+        Gem.clear_paths
         require name # require plugin for the templates, this registers the plugin
       rescue LoadError => e
         puts "#{e.class}: #{e.message}".color(:red)

--- a/terraspace.gemspec
+++ b/terraspace.gemspec
@@ -29,15 +29,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "memoist"
   spec.add_dependency "rainbow"
   spec.add_dependency "render_me_pretty"
-  spec.add_dependency "terraspace-bundler", "~> 0.4.0"
+  spec.add_dependency "rexml"
+  spec.add_dependency "terraspace-bundler", "~> 0.4.4"
   spec.add_dependency "thor"
   spec.add_dependency "tty-tree"
   spec.add_dependency "zeitwerk"
 
   # core baseline plugins
-  spec.add_dependency "terraspace_plugin_aws", "~> 0.3.0"
-  spec.add_dependency "terraspace_plugin_azurerm", "~> 0.3.0"
-  spec.add_dependency "terraspace_plugin_google", "~> 0.3.0"
   spec.add_dependency "rspec-terraspace", "~> 0.3.0"
 
   spec.add_development_dependency "bundler"


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Remove terraspace_plugin_* gems out of core terraspace gem.  Purpose:

* Make terraspace core gem more lightweight
* Mitigates gem dependencies issues. This doesn't solve it completely and believe a shim will be required for some cases. See: https://terraspace.cloud/docs/misc/shim/

## Context

Related: 

* https://github.com/boltops-tools/terraspace-bundler/pull/16 Removed google-cloud-storage from terraspace-bundler since it's not as popular and was triggering a faraday gem dependency.
* https://github.com/boltops-tools/terraspace/issues/137 terraspace_plugin_aws does not require the faraday gem since the aws-sdk-* gems do not use faraday. For terraspace_plugin_google and terraspace_plugin_azurerm, those both use the faraday gem, so not much can do about that.
* https://github.com/boltops-tools/terraspace/issues/135 - The "You have already activated" message is explained in https://terraspace.cloud/docs/misc/shim/ and https://terraspace.cloud/docs/install/gem/multiple-versions/ docs. It doesn't seem to suffice. Will probably follow up and add a friendly message to the user to explain how a shim or `bundle update` so the system gems match what's in the `Gemfile.lock` is a way to remove the message. 
* https://github.com/boltops-tools/terraspace/issues/163 The related https://terraspace.cloud/docs/install/gem/version-locking/ docs also explain to users how they can control additional gem dependencies with more granular control. 

## How to Test

Go through getting started guides and make sure that they work: https://terraspace.cloud/getting-started/

## Version Changes

Minor