### PR TITLE
support non-cloud providers and backends

### DIFF
--- a/lib/terraspace/compiler/backend.rb
+++ b/lib/terraspace/compiler/backend.rb
@@ -16,6 +16,7 @@ module Terraspace::Compiler
       klass = backend_interface(backend_name)
       return unless klass # in case auto-creation is not supported for specific backend
 
+      # IE: TerraspacePluginAws::Interfaces::Backend.new
       interface = klass.new(backend_info)
       interface.call
     end

--- a/lib/terraspace/compiler/expander/backend.rb
+++ b/lib/terraspace/compiler/expander/backend.rb
@@ -1,0 +1,43 @@
+# Simpler than Terraspace::Compiler::Backend::Parser because
+# Terraspace::Compiler::Expander autodetect backend super early on.
+# It's so early that don't want helper methods like <%= expansion(...) %> to be called.
+# Calling the expansion helper itself results in Terraspace autodetecting a concrete
+# Terraspace Plugin Expander, which creates an infinite loop.
+# This simple detection class avoids calling ERB and avoids the infinite loop.
+class Terraspace::Compiler::Expander
+  class Backend
+    extend Memoist
+
+    def initialize(mod)
+      @mod = mod
+    end
+
+    COMMENT = /^\s+#/
+    # Works for both backend.rb DSL and backend.tf ERB
+    def detect
+      lines = IO.readlines(src_path)
+      backend_line = lines.find { |l| l.include?("backend") && l !~ COMMENT }
+      md = backend_line.match(/['"](.*)['"]/)
+      md[1] if md
+    end
+
+  private
+    # Use original unrendered source as wont know the
+    # @mod.cache_dir = ":CACHE_ROOT/:REGION/:ENV/:BUILD_DIR"
+    # Until the concrete Terraspace Plugin Expander has been autodetected.
+    # Follow same precedence rules as rest of Terraspace.
+    def src_path
+      exprs = [
+        "app/stacks/#{@mod.build_dir}/backend.*",
+        "app/modules/#{@mod.build_dir}/backend.*",
+        "vendor/stacks/#{@mod.build_dir}/backend.*",
+        "vendor/modules/#{@mod.build_dir}/backend.*",
+        "config/terraform/backend.*",
+      ]
+      path = nil
+      exprs.find { |expr| path = Dir.glob(expr).first }
+      path
+    end
+    memoize :src_path
+  end
+end

--- a/lib/terraspace/plugin/expander/interface.rb
+++ b/lib/terraspace/plugin/expander/interface.rb
@@ -70,7 +70,10 @@ module Terraspace::Plugin::Expander
     #
     def strip(string)
       string.sub(/^-+/,'').sub(/-+$/,'') # remove leading and trailing -
-            .sub(%r{/+$},'') # only remove trailing / or else /home/ec2-user => home/ec2-user
+            .sub(%r{/+$},'')  # only remove trailing / or else /home/ec2-user => home/ec2-user
+            .sub(/:\/\//, 'TMP_KEEP_HTTP') # so we can keep ://. IE: https:// or http://
+            .gsub(%r{/+},'/') # remove double slashes are more. IE: // -> / Useful of region is '' in generic expander
+            .sub('TMP_KEEP_HTTP', '://')   # restore :// IE: https:// or http://
     end
 
     def var_value(name)
@@ -101,6 +104,14 @@ module Terraspace::Plugin::Expander
 
     def cache_root
       Terraspace.cache_root
+    end
+
+    # So default config works:
+    #    config.cache_dir = ":CACHE_ROOT/:REGION/:ENV/:BUILD_DIR"
+    # For when folks configure it with the http backend for non-cloud providers
+    # The double slash // will be replace with a single slash in expander/interface.rb
+    def region
+      ''
     end
   end
 end

--- a/lib/terraspace/terraform/runner/retryer.rb
+++ b/lib/terraspace/terraform/runner/retryer.rb
@@ -9,7 +9,7 @@ class Terraspace::Terraform::Runner
     end
 
     def retry?
-      max_retries = ENV['TS_MAX_RETRIES'] ? ENV['TS_MAX_RETRIES'].to_i : 3
+      max_retries = ENV['TS_MAX_RETRIES'] ? ENV['TS_MAX_RETRIES'].to_i : 1
       if @retries <= max_retries && !@stop_retrying
         true # will retry
       else


### PR DESCRIPTION
* decouple backend detection from plugins
* expander backend detection that doesn't evaluate ERB

This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Support for non-cloud providers and backends by decoupling the backend detection from terraspace plugins. The backend detection is simpler and will not run ERB on the detection pass. With the normal compile pass, it will run ERB.

## Context

* Fixes https://github.com/boltops-tools/terraspace/issues/160
* Fixes https://github.com/boltops-tools/terraspace/issues/131
* Fixes https://github.com/boltops-tools/terraspace/issues/132
* Related docs PR: https://github.com/boltops-tools/terraspace-docs/pull/21

Seems like folks are using the gitlab backend.

This allows folks to use the http backend or any other backend https://www.terraform.io/language/settings/backends/local

## How to Test

Use a backend example like what @yisyang provided in https://github.com/boltops-tools/terraspace/issues/160#issuecomment-978846125 and @Grummfy https://github.com/boltops-tools/terraspace-docs/issues/16 Example:

config/terraform/backend.tf:

```
terraform {
  backend "http" {
    address        = "<%= ENV['GITLAB_PROJECT_URL'] %>/<%= expansion(":ENV-:TYPE_DIR-:MOD_NAME") %>"
    lock_address   = "<%= ENV['GITLAB_PROJECT_URL'] %>/<%= expansion(":ENV-:TYPE_DIR-:MOD_NAME") %>/lock"
    unlock_address = "<%= ENV['GITLAB_PROJECT_URL'] %>/<%= expansion(":ENV-:TYPE_DIR-:MOD_NAME") %>/lock"
    username       = "<%= ENV['GITLAB_USER'] %>"
    password       = "<%= ENV['GITLAB_ACCESS_TOKEN'] %>"
    lock_method    = "POST"
    unlock_method  = "DELETE"
    retry_wait_min = 5
  }
}
```

You can set the env var defaults with the [config/boot.rb](https://terraspace.cloud/docs/config/boot/) hook.

config/boot.rb:

```ruby
ENV['GITLAB_PROJECT_ID']   ||= 'your project id'
ENV['GITLAB_USER']         ||= 'gitlab-user'
ENV['GITLAB_ACCESS_TOKEN'] ||= 'gitlab-api-access-token'
ENV['GITLAB_PROJECT_URL']    = "https://gitlab.com/api/v4/projects/#{ENV['GITLAB_PROJECT_ID']}/terraform/state"
```


Note: Using `:ENV-:TYPE_DIR-:MOD_NAME` which includes env, stacks/modules as a prefix in the state path name to generalize. If you're sure that you're not going to be deploying `app/modules` directly, you can use the simpler `:MOD_NAME-:ENV`. Though like the shorter path, showing the generalized one just in case and to avoid possible people in the future venting 🤣  It does not include region because the http backend results in a generic expander being used. Once this is released and docs are merged in also, there is an example of how you add the region in the docs. You can also see this PR: https://github.com/boltops-tools/terraspace-docs/pull/21 right now.

For backend variables, see: https://terraspace.cloud/docs/config/backend/variables/

Also, notice instead of the use of `-` instead of `/`. This is because the GitLab http backend urls are resource urls. Using `/` will mean a different url resource. So we have to use `-`. IE: `:ENV-:TYPE_DIR-:MOD_NAME` vs `:ENV/:TYPE_DIR/:MOD_NAME`

* GitLab Docs: [GitLab managed Terraform State](https://docs.gitlab.com/ee/user/infrastructure/iac/terraform_state.html)

## Local Backend

Also, tested with local backend. Here's an example:

config/terraform/backend.tf

```terraform
terraform {
  backend "local" {
    path = "<%= expansion('.terraform/state.tfstate') %>"
  }
}
```

The local statefile is stored at:

    ls .terraspace-cache/dev/stacks/demo/.terraform/state.tfstate

Docs for this will also be in this docs PR https://github.com/boltops-tools/terraspace-docs/pull/21

## Version Changes

Minor