### PR TITLE
Shim

### DIFF
--- a/lib/terraspace/autoloader.rb
+++ b/lib/terraspace/autoloader.rb
@@ -1,6 +1,10 @@
 require "terraspace/bundle"
 Terraspace::Bundle.setup
-require "zeitwerk"
+begin
+  require "zeitwerk"
+rescue LoadError => e
+  Terraspace::Bundle.handle_already_activated_error(e)
+end
 
 module Terraspace
   # These modules are namespaces for user-defined custom helpers
@@ -38,3 +42,4 @@ module Terraspace
     end
   end
 end
+

--- a/lib/terraspace/bundle.rb
+++ b/lib/terraspace/bundle.rb
@@ -95,15 +95,7 @@ module Terraspace
     end
 
     def check_shim!
-      return unless which_installed?
-      # shelling out to `type` doesnt work since its a built-in? so using which
-      out = `which terraspace`
-      path = out.strip.split("\n").last
-      lines = IO.readlines(path)
-      found = lines.detect { |l| l.include?('bundle exec') }
-      return if found
       return unless File.exist?("Gemfile")
-
       $stderr.puts <<~EOL
         Looks like there are issues trying to resolve gem dependencies.
 
@@ -117,9 +109,6 @@ module Terraspace
       EOL
     end
 
-    def which_installed?
-      system "type which > /dev/null 2>&1"
-    end
     extend self
   end
 end

--- a/lib/terraspace/command.rb
+++ b/lib/terraspace/command.rb
@@ -71,7 +71,7 @@ module Terraspace
         version_manager = "rvm" if rvm?
         version_manager = "rbenv" if rbenv?
         if rbenv? || rvm?
-          puts <<~EOL.color(:yellow)
+          $stderr.puts <<~EOL.color(:yellow)
             WARN: It looks like a standalone Terraspace install and #{version_manager} is also in use.
             Different gems from the standalone Terraspace install and #{version_manager} can cause all kinds of trouble.
             Please install Terraspace as a gem instead and remove the standalone Terraspace /opt/terraspace installation.


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Provide a friendly-error message to users when there are gem dependency issues. 

## Context

Related: https://github.com/boltops-tools/terraspace/pull/173

## How to Test

In alpine docker container, install different versions of terraspace. Update the `Gemfile` in the Terraspace project to a the older version of terraspace. Then run:

    terraspace -v

It should show the friendly-error message.

## Version Changes

Patch