### PR TITLE
fix no backend.tf src file case

### DIFF
--- a/lib/terraspace/compiler/expander/backend.rb
+++ b/lib/terraspace/compiler/expander/backend.rb
@@ -15,6 +15,7 @@ class Terraspace::Compiler::Expander
     COMMENT = /^\s+#/
     # Works for both backend.rb DSL and backend.tf ERB
     def detect
+      return nil unless src_path # no backend file. returning nil means a local backend
       lines = IO.readlines(src_path)
       backend_line = lines.find { |l| l.include?("backend") && l !~ COMMENT }
       md = backend_line.match(/['"](.*)['"]/)


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix for case when no `config/terraform/backend.tf` or `config/terraform/backend.rb` exists.

## Context

* https://github.com/boltops-tools/terraspace/pull/174

## How to Test

Run codebuild ingreration tests, which do this:

    terraspace new project infra --examples
    cd infra
    terraspace new test demo --type stack
    cd app/stacks/demo
    terraspace test

## Version Changes

Patch