### PR TITLE
terraspace check setup command

### DIFF
--- a/lib/terraspace/builder.rb
+++ b/lib/terraspace/builder.rb
@@ -8,7 +8,7 @@ module Terraspace
 
     def run
       return if @options[:build] == false
-      Terraspace::CLI::CheckSetup.check!
+      Terraspace::CLI::Setup::Check.check!
       @mod.root_module = true
       clean
       build_dir = Util.pretty_path(@mod.cache_dir)

--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -42,6 +42,10 @@ module Terraspace
     long_desc Help.text(:new)
     subcommand "new", New
 
+    desc "setup SUBCOMMAND", "setup subcommands"
+    long_desc Help.text(:setup)
+    subcommand "setup", Setup
+
     desc "tfc SUBCOMMAND", "tfc subcommands"
     long_desc Help.text(:tfc)
     subcommand "tfc", Tfc
@@ -64,7 +68,13 @@ module Terraspace
     desc "check_setup", "Check setup."
     long_desc Help.text(:check_setup)
     def check_setup
-      CheckSetup.new(options).run
+      puts <<~EOL
+        DEPRECATED: The terraspace check_setup command is deprecated. Instead use:
+
+            terraspace setup check
+
+      EOL
+      Setup::Check.new(options).run
     end
 
     desc "console STACK", "Run console in built terraform project."

--- a/lib/terraspace/cli/concern.rb
+++ b/lib/terraspace/cli/concern.rb
@@ -52,12 +52,12 @@ class Terraspace::CLI
           recursive
           upgrade
         ]
+        args = single_word_boolean_args.map { |s| "-#{s}" }
         argv.map! do |arg|
-          word = arg.sub(/^-/,'')
-          if single_word_boolean_args.include?(word)
-            # Add double dash (--).
+          if args.include?(arg)
+            # Ensure double dash (--).
             # Later in Terraspace::Terraform::Args::Pass#args a single dash (-) is ensured.
-            "--#{word}" # IE: destroy => --destroy
+            "-#{arg}" # IE: -destroy => --destroy
           else
             arg
           end

--- a/lib/terraspace/cli/setup.rb
+++ b/lib/terraspace/cli/setup.rb
@@ -1,0 +1,9 @@
+class Terraspace::CLI
+  class Setup < Terraspace::Command
+    desc "check", "Check setup is ok"
+    long_desc Help.text("setup/check")
+    def check
+      Check.new(options).run
+    end
+  end
+end

--- a/lib/terraspace/cli/setup/check.rb
+++ b/lib/terraspace/cli/setup/check.rb
@@ -1,5 +1,5 @@
-class Terraspace::CLI
-  class CheckSetup
+class Terraspace::CLI::Setup
+  class Check
     extend Memoist
 
     # Terraspace requires at least this version of terraform

--- a/lib/terraspace/command.rb
+++ b/lib/terraspace/command.rb
@@ -102,7 +102,7 @@ module Terraspace
         return if subcommand?
         return if command_name.nil?
         return if help_flags.include?(Terraspace.argv.last) # IE: -h help
-        return if %w[-h -v --version check_setup completion completion_script help new test version].include?(command_name)
+        return if %w[-h -v --version check_setup completion completion_script help new setup test version].include?(command_name)
         return if File.exist?("#{Terraspace.root}/config/app.rb")
         logger.error "ERROR: It doesnt look like this is a terraspace project. Are you sure you are in a terraspace project?".color(:red)
         ENV['TS_TEST'] ? raise : exit(1)


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Deprecate

    terraspace check_setup

For

    terraspace setup check

## Context

* Related: Also, tighten up the terraform single word boolean args in https://github.com/boltops-tools/terraspace/pull/172

## How to Test

Run

    terraspace setup check

## Version Changes

Patch