### PR TITLE
hide check_setup command

### DIFF
--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -65,7 +65,7 @@ module Terraspace
       Bundle.new(options.merge(args: args)).run
     end
 
-    desc "check_setup", "Check setup."
+    desc "check_setup", "Check setup.", hide: true
     long_desc Help.text(:check_setup)
     def check_setup
       puts <<~EOL


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

hide deprecated `terraspace check_setup` command from help menu.

## Context

* https://github.com/boltops-tools/terraspace/pull/179

## How to Test

Run

    terraspace -h

Confirm command does not show up

## Version Changes

Patch