### PR TITLE
move backend auto creation to runner stage

### DIFF
--- a/lib/terraspace/builder.rb
+++ b/lib/terraspace/builder.rb
@@ -20,7 +20,6 @@ module Terraspace
       run_hooks("terraspace.rb", "build") do
         check_allow!
         build_unresolved
-        auto_create_backend
         batches = build_batches
         build_all
         logger.info "Built in #{build_dir}" unless @options[:quiet] # from terraspace all
@@ -64,13 +63,6 @@ module Terraspace
         next if is_root_module # handled by build_root_module
         Compiler::Builder.new(mod).build
       end
-    end
-
-    # Auto create after build_unresolved since will need to run state pull for dependencies
-    def auto_create_backend
-      return if Terraspace.config.auto_create_backend == false
-      return unless requires_backend?
-      Terraspace::Compiler::Backend.new(@mod).create
     end
 
     def clean

--- a/lib/terraspace/cli/tfc_concern.rb
+++ b/lib/terraspace/cli/tfc_concern.rb
@@ -7,7 +7,7 @@ class Terraspace::CLI
     end
 
     def backend
-      Terraspace::Compiler::Backend::Parser.new(@mod).result
+      Terraspace::Terraform::Runner::Backend::Parser.new(@mod).result
     end
     memoize :backend
   end

--- a/lib/terraspace/compiler/commands_concern.rb
+++ b/lib/terraspace/compiler/commands_concern.rb
@@ -1,13 +1,5 @@
 module Terraspace::Compiler
   module CommandsConcern
-    def requires_backend?
-      command_is?(requires_backend_commands)
-    end
-
-    def requires_backend_commands
-      %w[down init output plan providers refresh show up validate]
-    end
-
     def command_is?(*commands)
       commands.flatten!
       commands.map!(&:to_s)

--- a/lib/terraspace/compiler/expander/backend.rb
+++ b/lib/terraspace/compiler/expander/backend.rb
@@ -1,4 +1,4 @@
-# Simpler than Terraspace::Compiler::Backend::Parser because
+# Simpler than Terraspace::Terraform::Runner::Backend::Parser because
 # Terraspace::Compiler::Expander autodetect backend super early on.
 # It's so early that don't want helper methods like <%= expansion(...) %> to be called.
 # Calling the expansion helper itself results in Terraspace autodetecting a concrete

--- a/lib/terraspace/terraform/api/client.rb
+++ b/lib/terraspace/terraform/api/client.rb
@@ -16,7 +16,7 @@ class Terraspace::Terraform::Api
 
     # backend may be overridden in classes including this Concern
     def backend
-      Terraspace::Compiler::Backend::Parser.new(@mod).result
+      Terraspace::Terraform::Runner::Backend::Parser.new(@mod).result
     end
     memoize :backend
 

--- a/lib/terraspace/terraform/runner.rb
+++ b/lib/terraspace/terraform/runner.rb
@@ -46,6 +46,7 @@ module Terraspace::Terraform
       params = args.flatten.join(' ')
       command = "terraform #{name} #{params}".squish
       run_hooks("terraform.rb", name) do
+        Backend.new(@mod).create
         run_internal_hook(:before, name)
         Terraspace::Shell.new(@mod, command, @options.merge(env: custom.env_vars)).run
         run_internal_hook(:after, name)

--- a/lib/terraspace/terraform/runner/backend/parser.rb
+++ b/lib/terraspace/terraform/runner/backend/parser.rb
@@ -1,6 +1,6 @@
 require "hcl_parser"
 
-class Terraspace::Compiler::Backend
+class Terraspace::Terraform::Runner::Backend
   class Parser
     extend Memoist
 

--- a/lib/terraspace/terraform/tfc/sync.rb
+++ b/lib/terraspace/terraform/tfc/sync.rb
@@ -35,7 +35,7 @@ module Terraspace::Terraform::Tfc
 
     # already memoized in Api::Client
     def backend
-      Terraspace::Compiler::Backend::Parser.new(@mod).result
+      Terraspace::Terraform::Runner::Backend::Parser.new(@mod).result
     end
   end
 end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Refactoring. Moving the backend auto-creation logic to the Runner phase instead of the Compiler phase. It still pretty much works the same way.

## How to Test

Sanity check with new project in the Getting Started Guides.

## Version Changes

Patch