### PR TITLE
fix example generator lang option

### DIFF
--- a/lib/templates/examples/hcl/module/main.tf
+++ b/lib/templates/examples/hcl/module/main.tf
@@ -1,5 +1,3 @@
 resource "random_pet" "this" {
-  keepers = {
-    name = var.name
-  }
+  length = var.length
 }

--- a/lib/templates/examples/hcl/module/variables.tf
+++ b/lib/templates/examples/hcl/module/variables.tf
@@ -1,5 +1,5 @@
-variable "name" {
-  type        = string
-  description = "pet name"
-  default     = "example-name"
+variable "length" {
+  type        = number
+  description = "number of words"
+  default     = 2
 }

--- a/lib/templates/examples/hcl/stack/main.tf
+++ b/lib/templates/examples/hcl/stack/main.tf
@@ -1,4 +1,4 @@
 module "pet" {
   source     = "../../modules/example"
-  name       = var.name
+  length     = var.length
 }

--- a/lib/templates/examples/hcl/stack/variables.tf
+++ b/lib/templates/examples/hcl/stack/variables.tf
@@ -1,5 +1,5 @@
-variable "name" {
-  type        = string
-  description = "pet name"
-  default     = "demo-name"
+variable "length" {
+  type        = number
+  description = "number of words"
+  default     = 2
 }

--- a/lib/templates/examples/ruby/module/main.rb
+++ b/lib/templates/examples/ruby/module/main.rb
@@ -1,5 +1,3 @@
 resource("random_pet", "this",
-  keepers: {
-    name: var.name
-  }
+  length: var.length
 )

--- a/lib/templates/examples/ruby/module/variables.rb
+++ b/lib/templates/examples/ruby/module/variables.rb
@@ -1,4 +1,5 @@
-variable("name",
-  description: "pet name",
-  default:     "example-name",
+variable("length",
+  type:        :number,
+  description: "number of words",
+  default:     2,
 )

--- a/lib/templates/examples/ruby/stack/main.rb
+++ b/lib/templates/examples/ruby/stack/main.rb
@@ -1,4 +1,4 @@
 module!("pet",
   source: "../../modules/example",
-  name:   var.name,
+  length: var.length,
 )

--- a/lib/templates/examples/ruby/stack/variables.rb
+++ b/lib/templates/examples/ruby/stack/variables.rb
@@ -1,4 +1,5 @@
-variable("name",
-  description: "pet name",
-  default:     "demo-name",
+variable("length",
+  type:        :number,
+  description: "number of words",
+  default:     2,
 )

--- a/lib/templates/hcl/project/config/terraform/provider.tf
+++ b/lib/templates/hcl/project/config/terraform/provider.tf
@@ -1,25 +1,6 @@
-# This is where you put your provider declaration. Here are some examples:
+# This is where you put your provider declaration.
 #
-# provider "aws" {
-#   region = "<%= ENV['AWS_REGION'] || 'us-east-1' %>"
-# }
-#
-# Docs: https://www.terraform.io/docs/providers/aws/index.html
-#
-# provider "azurerm" {
-#   features {} # required
-# }
-#
-# Docs: https://www.terraform.io/docs/providers/aws/index.html
-#
-# provider "google" {
-#   project = "REPLACE_ME"
-#   region  = "us-central1"   # update to your region
-#   zone    = "us-central1-a" # update to your zone
-# }
-#
-# Docs: https://www.terraform.io/docs/providers/google/index.html
-#
-# Note: If you add a provider, you should also configure a terraspace_plugin_* gem
+# If you end up adding a cloud provider, you should also configure a terraspace_plugin_* gem
 # in the Terraspace project Gemfile and run bundle.
 #
+# See: https://terraspace.cloud/docs/plugins/

--- a/lib/terraspace/cli/new/example.rb
+++ b/lib/terraspace/cli/new/example.rb
@@ -8,8 +8,9 @@ class Terraspace::CLI::New
     def self.options
       # default is nil for autodetection
       [
-        [:plugin, aliases: %w[p], default: nil, type: :string],
         [:force, aliases: %w[f], type: :boolean, desc: "Force overwrite"],
+        [:lang, default: "hcl", desc: "Language to use: HCL/ERB or Ruby DSL"],
+        [:plugin, aliases: %w[p], default: nil, type: :string],
       ]
     end
     options.each { |args| class_option(*args) }
@@ -28,6 +29,7 @@ class Terraspace::CLI::New
         ['--plugin', 'none'] # override default of aws
       end
       args << "--force" if @options[:force]
+      args += ["--lang", @options[:lang]] if @options[:lang]
       args
     end
   end

--- a/lib/terraspace/cli/new/stack.rb
+++ b/lib/terraspace/cli/new/stack.rb
@@ -2,7 +2,8 @@ class Terraspace::CLI::New
   class Stack < Sequence
     component_options.each { |args| class_option(*args) }
 
-    argument :name
+    # default so terraspace new example works without a Thor warning
+    argument :name, default: "demo"
 
     def create_stack
       puts "=> Creating new stack called #{name}"


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix `--lang` option for `terraspace new example`

## How to Test

    terraspace new example --lang ruby

## Version Changes

Patch