### PR TITLE
pass value through untouch when expand method not defined

### DIFF
--- a/lib/terraspace/plugin/expander/interface.rb
+++ b/lib/terraspace/plugin/expander/interface.rb
@@ -76,9 +76,13 @@ module Terraspace::Plugin::Expander
             .sub('TMP_KEEP_HTTP', '://')   # restore :// IE: https:// or http://
     end
 
-    def var_value(name)
-      name = name.sub(':','').downcase
-      value = send(name).to_s
+    def var_value(unexpanded)
+      name = unexpanded.sub(':','').downcase
+      if respond_to?(name)
+        value = send(name).to_s
+      else
+        return unexpanded
+      end
       if name == "namespace" && Terraspace.config.layering.enable_names.expansion
         value = friendly_name(value)
       end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

When an expansion method is not defined in the provider plugin, instead of raising an error, it'll pass the value straight through. IE:

    "test-:ENV-:ENV2-example"

Results in:

    "test-dev-:ENV2-example"

Since `:ENV2` is not defined in the provider plugins. 

## Context

Would had helped with this:

* https://github.com/boltops-tools/terraspace/pull/162
* https://github.com/boltops-tools/terraspace_plugin_aws/pull/10

## How to Test

Use a test string like in ERB somewhere.

    # <%= expansion("test-dev-:ENV2-example") %>

And run

    terraspace build

## Version Changes

Patch