### PR TITLE
put thor cli options at the end

### DIFF
--- a/lib/terraspace/terraform/runner.rb
+++ b/lib/terraspace/terraform/runner.rb
@@ -18,7 +18,7 @@ module Terraspace::Terraform
 
     # default at end in case of redirection. IE: terraform output > /path
     def args
-      args = custom.args + thor.args + pass.args
+      args = custom.args + pass.args + thor.args
       args.uniq
     end
 
@@ -28,17 +28,17 @@ module Terraspace::Terraform
     end
     memoize :custom
 
-    # From Thor defined/managed cli @options
-    def thor
-      Args::Thor.new(@mod, @name, @options)
-    end
-    memoize :thor
-
     # From Thor passthrough cli @options[:args]
     def pass
       Args::Pass.new(@mod, @name, @options)
     end
     memoize :pass
+
+    # From Thor defined/managed cli @options
+    def thor
+      Args::Thor.new(@mod, @name, @options)
+    end
+    memoize :thor
 
     def terraform(name, *args)
       current_dir_message # only show once


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This makes the underlying `terraform init` command prettier and easier on the eyes 👀 when they are printed out.  It works the same either way.

## Context

https://github.com/boltops-tools/terraspace/pull/172

## How to Test

Sanity check with a new terraspace project.

## Version Changes

Patch