### PR TITLE
dotenv support

### DIFF
--- a/lib/templates/base/project/.gitignore
+++ b/lib/templates/base/project/.gitignore
@@ -13,6 +13,7 @@ terraform.tfvars
 # Common ruby files
 *.gem
 *.rbc
+.env*
 .idea
 /.bundle
 /.config

--- a/lib/terraspace/booter.rb
+++ b/lib/terraspace/booter.rb
@@ -1,6 +1,7 @@
 module Terraspace
   module Booter
     def boot
+      Dotenv.new.load!
       run_hooks
       Terraspace::Bundle.require # load plugins
       load_plugin_default_configs

--- a/lib/terraspace/dotenv.rb
+++ b/lib/terraspace/dotenv.rb
@@ -1,0 +1,25 @@
+require 'dotenv'
+
+module Terraspace
+  class Dotenv
+    def load!
+      ::Dotenv.load(*files)
+    end
+
+    # dotenv files with the following precedence:
+    #
+    # - .env.dev.local - Highest precedence
+    # - .env.dev
+    # - .env.local
+    # - .env - Lowest precedence
+    #
+    def files
+      [
+        ".env.#{Terraspace.env}.local",
+        ".env.#{Terraspace.env}",
+        ".env.local",
+        ".env",
+      ].compact
+    end
+  end
+end

--- a/terraspace.gemspec
+++ b/terraspace.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bundler"
   spec.add_dependency "cli-format"
   spec.add_dependency "deep_merge"
+  spec.add_dependency "dotenv"
   spec.add_dependency "dsl_evaluator"
   spec.add_dependency "eventmachine-tail"
   spec.add_dependency "graph"


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Support loading of `.env` files within the current terraspace project folder.

- .env.dev.local - Highest precedence
- .env.dev
- .env.local
- .env - Lowest precedence

## Context

Community Forum Post: https://community.boltops.com/t/loading-env-file-in-hook/813

## How to Test

Create `.env` files and add a `config/boot.rb` to see env var set via .env

.env

    FOO=bar-base

.env.dev

    FOO=bar-dev

config/boot.rb

```ruby
puts "ENV['FOO'] #{ENV['FOO'].inspect}"
```

## Version Changes

Patch