### PR TITLE
update terraspace-bundler gem depedency to 0.5.0

### DIFF
--- a/terraspace.gemspec
+++ b/terraspace.gemspec
@@ -31,13 +31,13 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rainbow"
   spec.add_dependency "render_me_pretty"
   spec.add_dependency "rexml"
-  spec.add_dependency "terraspace-bundler", "~> 0.4.4"
+  spec.add_dependency "terraspace-bundler", ">= 0.5.0"
   spec.add_dependency "thor"
   spec.add_dependency "tty-tree"
   spec.add_dependency "zeitwerk"
 
   # core baseline plugins
-  spec.add_dependency "rspec-terraspace", "~> 0.3.0"
+  spec.add_dependency "rspec-terraspace", ">= 0.3.1"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Update terraspace-bundler dependency to `>= 0.5.0`

## Context

https://github.com/boltops-tools/terraspace-bundler/pull/17

## How to Test

Install terraspace and confirm at least terraspace-bundler 0.5.0 is used.

## Version Changes

Patch