### PR TITLE
run super-early boot hooks before dotenv load

### DIFF
--- a/lib/terraspace/booter.rb
+++ b/lib/terraspace/booter.rb
@@ -1,8 +1,8 @@
 module Terraspace
   module Booter
     def boot
-      Dotenv.new.load!
       run_hooks
+      Dotenv.new.load!
       Terraspace::Bundle.require # load plugins
       load_plugin_default_configs
       Terraspace::App::Inits.run_all


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Run super-early boot hooks before dotenv load. This is important because the dotenv load will use the `Teraspace.env` and then it's already too late to use boot hooks to set the default TS_ENV. Will update dotenv docs with a `config/inits` initializer to show users how to check that dotenv is working. 

Docs:

* https://terraspace.cloud/docs/config/boot/
* https://terraspace.cloud/docs/config/dotenv/
* https://terraspace.cloud/docs/config/inits/

## Context

* Fixes https://github.com/boltops-tools/terraspace/issues/191
* Related https://github.com/boltops-tools/terraspace/pull/189

## How to Test

config/boot.rb

```ruby
ENV['TS_ENV'] ||= 'qa'
puts "boot.rb called: Terraspace.env #{Terraspace.env}"
puts "boot.rb called: ENV['TS_ENV'] #{ENV['TS_ENV']}"
```

Run something like 

    terraspace plan demo

And confirm that the terraspace-cache folder has `qa` in the path instead of `dev`. IE:

    .terraspace-cache/us-west-2/qa/stacks/demo

## Version Changes

Patch