### PR TITLE
improve autodetection for plugin expander for backend like remote

### DIFF
--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -33,6 +33,8 @@ module Terraspace
       config.all.consider_allow_deny_stacks = true
 
       config.auto_create_backend = true
+      config.autodetect = ActiveSupport::OrderedOptions.new
+      config.autodetect.expander = nil
       config.build = ActiveSupport::OrderedOptions.new
       config.build.cache_dir = ":CACHE_ROOT/:REGION/:ENV/:BUILD_DIR"
       config.build.cache_root = nil # defaults to /full/path/to/.terraspace-cache

--- a/lib/terraspace/autodetect.rb
+++ b/lib/terraspace/autodetect.rb
@@ -2,13 +2,9 @@ module Terraspace
   class Autodetect
     def plugin
       plugins = Terraspace::Plugin.meta.keys
-      if plugins.size == 1
-        plugins.first
-      else
-        precedence = %w[aws azurerm google]
-        precedence.find do |p|
-          plugins.include?(p)
-        end
+      precedence = %w[aws azurerm google]
+      precedence.find do |p|
+        plugins.include?(p)
       end
     end
   end

--- a/lib/terraspace/compiler/expander/backend.rb
+++ b/lib/terraspace/compiler/expander/backend.rb
@@ -12,7 +12,7 @@ class Terraspace::Compiler::Expander
       @mod = mod
     end
 
-    COMMENT = /^\s+#/
+    COMMENT = /^\s*#/
     # Works for both backend.rb DSL and backend.tf ERB
     def detect
       return nil unless src_path # no backend file. returning nil means a local backend


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fixes expander auto-detection bug with remote backend and a terraspace cloud plugin like aws. IE:

config/teraform/backend.tf

```hcl
terraform {
  backend "remote" {
    organization = "<%= ENV['TFC_ORG'] %>" 
    workspaces {
      name = "<%= expansion('my-engine-:MOD_NAME-:ENV-:REGION-:ACCOUNT') %>"
    }
  }
}
```

When on-prem support was added, it changed the auto-detection to be only based what was parsed from `config/teraform/backend.tf`. So a `remote` backend would result in on-prem being detected, and the expansion variables would not be expanded correctly. Even though users would have `terraspace_plugin_aws` in their Gemfile and want to use the aws plugin expander, it would use the on-prem generic expander.

Before on-prem support, it was assumed that if the aws terraspace plugin was installed it would just use the aws plugin expander. That's why it previously worked. 

But with on-prem support, the backend can be `http`, `remote, etc and the terraspace plugin and its expander cannot be detected based on that. 

Instead, this fix improves auto-detection so that Terraspace auto-detects based on:

1. config.autodetect.expander - config setting that allows override of the auto-detection entirely.
2. backend.tf parsing - will try to find the s3, azurerm, gcs backend and use the right terraspace plugin based on that.
3. Gemfile: check what plugins are loaded in the Gemfile and auto-detect based on that.

#3 will solve the issue for users who were on 0.6 and had everything working.  So there is no need to configure #1. It should just work. 

#1 is provided as another configuration option if you need to override default auto-detection behavior.

## Context

https://community.boltops.com/t/remote-backend-issue-from-terraspace-1-0-0-and-later/824

## How to Test

Try a remote backend like so:

config/teraform/backend.tf

```hcl
terraform {
  backend "remote" {
    organization = "<%= ENV['TFC_ORG'] %>" 
    workspaces {
      name = "<%= expansion('my-engine-:MOD_NAME-:ENV-:REGION-:ACCOUNT') %>"
    }
  }
}
```

Confirm your Gemfile has:

Gemfile:

```ruby
gem "terraspace_plugin_aws"
```

Run

    terraspace build

It should expand out the variables using the aws terrspace plugin expander.  Example of something it'll look like:

    $ cat .terraspace-cache/us-west-2/dev/stacks/demo/backend.tf
    terraform {
      backend "remote" {
        organization = "boltops"
        workspaces {
          name = "demo-dev-us-west-2"
        }
      }
    }

## Version Changes

Patch