### PR TITLE
terraspace all: build modules in batches and only each specific stack

### DIFF
--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -55,6 +55,7 @@ module Terraspace
     option :quiet, type: :boolean, desc: "quiet output"
     instance_option.call
     yes_option.call
+    option :clean, type: :boolean, default: nil, desc: "Whether or not clean out .terraspace-cache folder first", hide: true
     def build(mod="placeholder")
       Terraspace::Builder.new(options.merge(mod: mod)).run # building any stack builds them all
     end

--- a/lib/terraspace/cli/init.rb
+++ b/lib/terraspace/cli/init.rb
@@ -52,7 +52,7 @@ class Terraspace::CLI
       return if meta['Dir'] == '.' # root is already built
 
       remote_mod = Terraspace::Mod::Remote.new(meta, @mod)
-      Terraspace::Compiler::Builder.new(remote_mod).build
+      Terraspace::Compiler::Perform.new(remote_mod).build
     end
 
     def auto?

--- a/lib/terraspace/compiler/perform/skip.rb
+++ b/lib/terraspace/compiler/perform/skip.rb
@@ -1,4 +1,4 @@
-class Terraspace::Compiler::Builder
+class Terraspace::Compiler::Perform
   class Skip
     def initialize(mod, src_path)
       @mod, @src_path = mod, src_path

--- a/lib/terraspace/compiler/strategy/tfvar.rb
+++ b/lib/terraspace/compiler/strategy/tfvar.rb
@@ -5,7 +5,7 @@ module Terraspace::Compiler::Strategy
       @order = 0
     end
 
-    def run
+    def run(write: true)
       layer_paths.each do |layer_path|
         ext = File.extname(layer_path).sub('.','')
         klass = strategy_class(ext)
@@ -14,6 +14,7 @@ module Terraspace::Compiler::Strategy
         strategy = klass.new(@mod, layer_path)
         content = strategy.run
 
+        next unless write
         dest_name = ordered_name(layer_path)
         writer = Terraspace::Compiler::Writer.new(@mod, dest_name: dest_name)
         writer.write(content)

--- a/lib/terraspace/dependency/resolver.rb
+++ b/lib/terraspace/dependency/resolver.rb
@@ -1,0 +1,19 @@
+module Terraspace::Dependency
+  class Resolver
+    include Terraspace::Compiler::DirsConcern
+
+    def initialize(options={})
+      @options = options
+    end
+
+    def resolve
+      with_each_mod("stacks") do |mod|
+        Terraspace::Compiler::Perform.new(mod).compile_tfvars(write: false)
+      end
+
+      dependencies = Terraspace::Dependency::Registry.data # populated dependencies resolved
+      @graph = Terraspace::Dependency::Graph.new(stack_names, dependencies, @options)
+      @graph.build # Returns batches to run
+    end
+  end
+end

--- a/terraspace.gemspec
+++ b/terraspace.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ["Tung Nguyen"]
   spec.email         = ["tung@boltops.com"]
   spec.summary       = "Terraspace: The Terraspace Framework"
-  spec.homepage      = "https://github.com/boltops-tools/terraspace"
+  spec.homepage      = "https://terraspace.cloud"
   spec.license       = "Apache-2.0"
 
   spec.files         = File.directory?('.git') ? `git ls-files`.split($/) : Dir.glob("**/*")


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix `terraspace all` commands so it works when `config.all.include_stacks` or `config.all.exclude_stacks` options are used.

Changed the way batch compiling and building works. All modules are first built and then only the specific stack is built and deployed.

* Terraspace::Dependencies::Resolver
* rename Compiler::Builder to Compiler::Perform. more mentally clear it's different

## Context

https://community.boltops.com/t/plan-stack-trace-error-after-making-change-to-existing-infra/828/4

## How to Test

See: https://community.boltops.com/t/plan-stack-trace-error-after-making-change-to-existing-infra/828/4

## Version Changes

Minor