### PR TITLE
all plan --output and all up --plan options

### DIFF
--- a/lib/templates/base/project/.gitignore
+++ b/lib/templates/base/project/.gitignore
@@ -5,6 +5,7 @@ terraform.tfvars
 *.tfstate*
 
 .terraspace-cache
+*.plan
 
 # OS X files
 .history

--- a/lib/terraspace/all/runner.rb
+++ b/lib/terraspace/all/runner.rb
@@ -76,7 +76,7 @@ module Terraspace::All
       @errors.each do |pid|
         mod_name = @pids[pid]
         terraspace_command = terraspace_command(mod_name)
-        logger.error "Error running: #{terraspace_command}. Check logs and fix the error.".color(:red)
+        logger.error "Error running: #{terraspace_command}. Fix the error above or check logs for the error.".color(:red)
       end
       unless @errors.empty?
         exit 2 if exit_on_fail?
@@ -103,7 +103,8 @@ module Terraspace::All
           log_path: log_path(mod_name),
           terraspace_command: terraspace_command(mod_name),
         }
-        Summary.new(data).run
+        # Its possible for log file to not get created if RemoteState::Fetcher#validate! fails
+        Summary.new(data).run if File.exist?(data[:log_path])
       end
     end
 

--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -17,6 +17,7 @@ module Terraspace
       config.all.concurrency = 5
       config.all.exit_on_fail = ActiveSupport::OrderedOptions.new
       config.all.exit_on_fail.down = true
+      config.all.exit_on_fail.plan = true
       config.all.exit_on_fail.up = true
 
       config.allow = ActiveSupport::OrderedOptions.new

--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -9,7 +9,7 @@ module Terraspace
       option :yes, aliases: :y, type: :boolean, desc: "-auto-approve the terraform apply"
     }
     out_option = Proc.new {
-      option :out, aliases: :o, desc: "Write the output to path"
+      option :out, aliases: :o, desc: "Output path. Can be a pattern like :MOD_NAME.plan"
     }
     input_option = Proc.new {
       option :input, type: :boolean, desc: "Ask for input for variables if not directly set."
@@ -191,7 +191,7 @@ module Terraspace
     desc "show STACK", "Run show."
     long_desc Help.text(:show)
     instance_option.call
-    option :plan, desc: "path to created.plan"
+    option :plan, desc: "Plan path. Can be a pattern like :MOD_NAME.plan"
     def show(mod, *args)
       Commander.new("show", options.merge(mod: mod, args: args)).run
     end

--- a/lib/terraspace/cli/all.rb
+++ b/lib/terraspace/cli/all.rb
@@ -38,6 +38,7 @@ class Terraspace::CLI
 
     desc "plan", "Run plan for all or multiple stacks."
     long_desc Help.text("all/plan")
+    option :out, aliases: :o, desc: "Output path. Can be a pattern like :MOD_NAME.plan"
     def plan(*stacks)
       Terraspace::All::Runner.new("plan", @options.merge(stacks: stacks)).run
     end
@@ -56,6 +57,7 @@ class Terraspace::CLI
 
     desc "up", "Deploy all or multiple stacks."
     long_desc Help.text("all/up")
+    option :plan, desc: "Plan path. Can be a pattern like :MOD_NAME.plan"
     def up(*stacks)
       Terraspace::All::Runner.new("up", @options.merge(stacks: stacks)).run
     end

--- a/lib/terraspace/cli/build/placeholder.rb
+++ b/lib/terraspace/cli/build/placeholder.rb
@@ -3,6 +3,7 @@
 # It's useful for the summary command.
 module Terraspace::CLI::Build
   class Placeholder
+    include Terraspace::Compiler::DirsConcern
     include Terraspace::Util::Logging
 
     def initialize(options={})
@@ -28,7 +29,8 @@ module Terraspace::CLI::Build
     def find_stack
       stack_paths = Dir.glob("{app,vendor}/stacks/*")
       stack_paths.select! do |path|
-        select = Terraspace::Compiler::Select.new(path)
+        stack_name = extract_stack_name(path)
+        select = Terraspace::Compiler::Select.new(stack_name)
         select.selected?
       end
       mod_path = stack_paths.last

--- a/lib/terraspace/cli/help/all/plan.md
+++ b/lib/terraspace/cli/help/all/plan.md
@@ -23,3 +23,13 @@
     terraspace plan a1:  Changes to Outputs:
     Time took: 11s
     $
+
+## Using Plan Outputs
+
+Using plan output path. You can specify an output path for the plan that contains pattern for expansion. Example:
+
+    $ terraspace all plan --out ":MOD_NAME.plan"
+
+You can then use this later in terraspace up:
+
+    $ terraspace all up --plan ":MOD_NAME.plan"

--- a/lib/terraspace/cli/help/all/up.md
+++ b/lib/terraspace/cli/help/all/up.md
@@ -25,3 +25,13 @@ Once you confirm, Terraspace deploys the batches in parallel. Essentially, Terra
     Time took: 25s
 
 Terraspace provides a reduced-noise summary of the runs. The full logs are also written for further inspection and debugging. The [terraspace log](https://terraspace.cloud/reference/terraspace-log/) command is useful for viewing the logs.
+
+## Using Plans
+
+Using plan output path. You can specify an output path for the plan that contains pattern for expansion. Example:
+
+    $ terraspace all plan --out ":MOD_NAME.plan"
+
+You can then use this later in terraspace up:
+
+    $ terraspace all up --plan ":MOD_NAME.plan"

--- a/lib/terraspace/cli/help/plan.md
+++ b/lib/terraspace/cli/help/plan.md
@@ -27,3 +27,11 @@
     "terraform apply" is subsequently run.
 
     $
+
+Using plan output path. You can specify an output path for the plan. Example:
+
+    $ terraspace plan demo --out "my.plan"
+
+You can then use this later in terraspace up:
+
+    $ terraspace up demo --plan "my.plan"

--- a/lib/terraspace/cli/help/up.md
+++ b/lib/terraspace/cli/help/up.md
@@ -28,3 +28,11 @@
     bucket_name = bucket-trusty-marmoset
     Time took: 39s
     $
+
+Using plan output path. You can specify an output path for the plan. Example:
+
+    $ terraspace plan demo --out "my.plan"
+
+You can then use this later in terraspace up:
+
+    $ terraspace up demo --plan "my.plan"

--- a/lib/terraspace/compiler/dirs_concern.rb
+++ b/lib/terraspace/compiler/dirs_concern.rb
@@ -37,8 +37,13 @@ module Terraspace::Compiler
     #   path     /home/ec2-user/environment/downloads/infra/app/stacks/demo
     def select_stack?(type_dir, path)
       return true unless type_dir == "stacks"
-      select = Terraspace::Compiler::Select.new(path)
+      stack_name = extract_stack_name(path)
+      select = Terraspace::Compiler::Select.new(stack_name)
       select.selected?
+    end
+
+    def extract_stack_name(path)
+      path.sub(%r{.*(app|vendor)/stacks/}, '')
     end
 
     def local_paths(type_dir)

--- a/lib/terraspace/compiler/select.rb
+++ b/lib/terraspace/compiler/select.rb
@@ -3,9 +3,8 @@ module Terraspace::Compiler
     include Terraspace::App::CallableOption::Concern
     include Terraspace::Util::Logging
 
-    def initialize(path)
-      @path = path
-      @stack_name = extract_stack_name(path)
+    def initialize(stack_name)
+      @stack_name = stack_name
     end
 
     def selected?
@@ -59,10 +58,6 @@ module Terraspace::Compiler
   private
     def config
       Terraspace.config
-    end
-
-    def extract_stack_name(path)
-      path.sub(%r{.*(app|vendor)/stacks/}, '')
     end
 
     @@ignore_stacks_deprecation_warning = nil

--- a/lib/terraspace/terraform/args/expand.rb
+++ b/lib/terraspace/terraform/args/expand.rb
@@ -1,0 +1,25 @@
+module Terraspace::Terraform::Args
+  class Expand
+    class << self
+      def option_method(*names)
+        names.compact.each do |name|
+          option_method_each(name)
+        end
+      end
+
+      def option_method_each(name)
+        define_method name do
+          return unless @options[name]
+          expander = Terraspace::Compiler::Expander.autodetect(@mod)
+          expander.expansion(@options[name]) # pattern is a String that contains placeholders for substitutions
+        end
+      end
+    end
+
+    def initialize(mod, options={})
+      @mod, @options = mod, options
+    end
+
+    option_method :plan, :out
+  end
+end

--- a/lib/terraspace/terraform/ihooks/after/plan.rb
+++ b/lib/terraspace/terraform/ihooks/after/plan.rb
@@ -1,8 +1,8 @@
 module Terraspace::Terraform::Ihooks::After
   class Plan < Terraspace::Terraform::Ihooks::Base
     def run
-      return if !@options[:out] || @options[:copy_to_root] == false
-      copy_to_root(@options[:out])
+      return if !out_option || @options[:copy_to_root] == false
+      copy_to_root(out_option)
     end
 
     def copy_to_root(file)

--- a/lib/terraspace/terraform/ihooks/base.rb
+++ b/lib/terraspace/terraform/ihooks/base.rb
@@ -4,5 +4,10 @@ module Terraspace::Terraform::Ihooks
       @name = name
       super(options)
     end
+
+    def out_option
+      expand = Terraspace::Terraform::Args::Expand.new(@mod, @options)
+      expand.out
+    end
   end
 end

--- a/lib/terraspace/terraform/ihooks/before/plan.rb
+++ b/lib/terraspace/terraform/ihooks/before/plan.rb
@@ -1,12 +1,10 @@
 module Terraspace::Terraform::Ihooks::Before
   class Plan < Terraspace::Terraform::Ihooks::Base
     def run
-      out = @options[:out]
-      return unless out
-      return if out =~ %r{^/} # not need to create parent dir for copy with absolute path
+      return unless out_option
+      return if out_option =~ %r{^/} # not need to create parent dir for copy with absolute path
 
-      out = @options[:out]
-      name = out.sub("#{Terraspace.root}/",'')
+      name = out_option.sub("#{Terraspace.root}/",'')
       dest = "#{@mod.cache_dir}/#{name}"
       FileUtils.mkdir_p(File.dirname(dest))
     end

--- a/lib/terraspace/terraform/remote_state/marker/output.rb
+++ b/lib/terraspace/terraform/remote_state/marker/output.rb
@@ -25,7 +25,7 @@ module Terraspace::Terraform::RemoteState::Marker
     end
 
     def warning
-      logger.warn "WARN: The #{@child_name} stack does not exist".color(:yellow)
+      logger.warn "WARN: The #{@child_name} stack does not exist or is configured to be not included. IE: config.all.include_stacks or config.all.exclude_stacks".color(:yellow)
       caller_line = caller.find { |l| l.include?('.tfvars') }
       return unless caller_line # specs dont have a tfvars file
       source_code = PrettyTracer.new(caller_line).source_code

--- a/spec/terraspace/all/runner_spec.rb
+++ b/spec/terraspace/all/runner_spec.rb
@@ -1,6 +1,7 @@
 describe Terraspace::All::Runner do
   let(:runner) do
     runner = described_class.new(command: "up", yes: true)
+    allow(runner).to receive(:build_modules)
     allow(runner).to receive(:build_batches).and_return(batches)
     allow(runner).to receive(:preview)
     # Just test to the point of the run_builder and deploy_batch


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* value processed by expander

## Using Plans

Using plan output path. You can specify an output path for the plan that contains pattern for expansion. Example:

    $ terraspace all plan --out ":MOD_NAME.plan"

You can then use this later in terraspace up:

    $ terraspace all up --plan ":MOD_NAME.plan"

## Context

Closes #156

## How to Test

See using plans above.

## Version Changes

Patch