### PR TITLE
build required dependent stacks as part of terraspace up

### DIFF
--- a/lib/terraspace/all/runner.rb
+++ b/lib/terraspace/all/runner.rb
@@ -54,13 +54,13 @@ module Terraspace::All
     end
 
     def build_modules
-      builder = Terraspace::Builder.new(@options.merge(mod: "placeholder", quiet: true, clean: true))
-      builder.build(modules: true, stack: false)
+      builder = Terraspace::Builder.new(@options.merge(mod: "placeholder", clean: true, quiet: true, include_stacks: :none))
+      builder.build(modules: true)
     end
 
     def build_stack(name)
-      builder = Terraspace::Builder.new(@options.merge(mod: name, quiet: true, clean: false))
-      builder.build(modules: false, stack: true)
+      builder = Terraspace::Builder.new(@options.merge(mod: name, clean: false, quiet: true, include_stacks: :root_only))
+      builder.build(modules: false)
     end
 
     def wait_for_child_proccess

--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -16,7 +16,7 @@ module Terraspace
       config.all = ActiveSupport::OrderedOptions.new
       config.all.concurrency = 5
       config.all.exit_on_fail = ActiveSupport::OrderedOptions.new
-      config.all.exit_on_fail.down = true
+      config.all.exit_on_fail.down = false
       config.all.exit_on_fail.plan = true
       config.all.exit_on_fail.up = true
 

--- a/lib/terraspace/builder/children.rb
+++ b/lib/terraspace/builder/children.rb
@@ -1,0 +1,42 @@
+class Terraspace::Builder
+  class Children
+    include Terraspace::Util::Logging
+
+    def initialize(mod, options={})
+      @mod, @options = mod, options
+      @queue = []
+    end
+
+    def build
+      dependencies = Terraspace::Dependency::Registry.data
+      # Find out if current deploy stack contains dependency
+      found = dependencies.find do |parent_child|
+        parent, _ = parent_child.split(':')
+        parent == @mod.name
+      end
+      return unless found
+
+      # Go down graph children, which are the dependencies to build a queue
+      parent, _ = found.split(':')
+      node = Terraspace::Dependency::Node.find_by(name: parent)
+      build_queue(node)
+
+      logger.debug "Terraspace::Builder::Children @queue #{@queue}"
+
+      # Process queue in reverse order to build leaf nodes first
+      @queue.reverse.each do |node|
+        mod = Terraspace::Mod.new(node.name, @options)
+        Terraspace::Compiler::Perform.new(mod).compile
+      end
+    end
+
+    # Use depth first traversal to build queue
+    def build_queue(node)
+      node.children.each do |child|
+        @queue << child
+        build_queue(child)
+      end
+      @queue
+    end
+  end
+end

--- a/lib/terraspace/dependency/resolver.rb
+++ b/lib/terraspace/dependency/resolver.rb
@@ -8,6 +8,7 @@ module Terraspace::Dependency
 
     def resolve
       with_each_mod("stacks") do |mod|
+        mod.resolved = false
         Terraspace::Compiler::Perform.new(mod).compile_tfvars(write: false)
       end
 

--- a/lib/terraspace/mod.rb
+++ b/lib/terraspace/mod.rb
@@ -15,6 +15,7 @@ module Terraspace
       @name, @options = placeholder(name), options
       @consider_stacks = options[:consider_stacks].nil? ? true : options[:consider_stacks]
       @instance = options[:instance]
+      @resolved = true # more common case
     end
 
     def placeholder(name)

--- a/lib/terraspace/plugin/summary/interface.rb
+++ b/lib/terraspace/plugin/summary/interface.rb
@@ -49,7 +49,7 @@ module Terraspace::Plugin::Summary
     def download_statefiles
       return unless download?
       FileUtils.rm_rf(@dest_folder)
-      logger.info("Downloading statefiles to #{@dest_folder}")
+      logger.debug("Downloading statefiles to #{@dest_folder}")
       download # INTERFACE METHOD
     end
 

--- a/lib/terraspace/terraform/remote_state/fetcher.rb
+++ b/lib/terraspace/terraform/remote_state/fetcher.rb
@@ -48,7 +48,7 @@ module Terraspace::Terraform::RemoteState
     def output_error(type)
       msg = case type
       when :key_not_found
-        "Output #{@output_key} was not found for the #{@parent.name} tfvars file. Either #{@child.name} stack has not been deployed yet or it does not have this output: #{@output_key}"
+        "Output #{@output_key} was not found for the #{@parent.name} tfvars file. Either #{@child.name} stack has not been deployed yet or it does not have this output: #{@output_key}. Also, if local backend is being used and has been removed/cleaned, then it will also result zero-byte state.json with the 'terraform state pull' used to download the terraform state and output will not be found."
       when :state_not_found
         "Output #{@output_key} could not be looked up for the #{@parent.name} tfvars file. #{@child.name} stack needs to be deployed"
       when :bucket_not_found
@@ -63,7 +63,7 @@ module Terraspace::Terraform::RemoteState
     @@download_shown = false
     def pull
       return if @@pull_successes[cache_key]
-      logger.info "Downloading tfstate files for dependencies defined in tfvars..." unless @@download_shown || @options[:quiet]
+      logger.debug "Downloading tfstate files for dependencies defined in tfvars..." unless @@download_shown || @options[:quiet]
       @@download_shown = true
       logger.debug "Downloading tfstate for stack: #{@child.name}"
 

--- a/spec/terraspace/compiler/erb/render_spec.rb
+++ b/spec/terraspace/compiler/erb/render_spec.rb
@@ -1,6 +1,10 @@
 describe Terraspace::Compiler::Erb::Render do
   let(:render) { described_class.new(mod, src_path) }
-  let(:mod)    { Terraspace::Mod.new("a1") }
+  let(:mod)    do
+    mod = Terraspace::Mod.new("a1")
+    mod.resolved = false
+    mod
+  end
 
   # Only testing mod unresolved as a sanity check and its worth the ROI.
   # The resolved would the Fetcher. We have unit tests to cover those other changes.


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
This is a 🧐 documentation change.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix `terraspace up` when tfvars files are that define terraspace dependencies with `<%= output ... %>`. This was broken by https://github.com/boltops-tools/terraspace/pull/196 🤦🏻‍♂️  

Also, improved warning message when local backend is used and those files are removed/cleaned up as this can result in a zero-byte downloaded `state.json` file with `terraform state pull`.

Also:

* also cleanup mod.resolved
* change default `config.exit_on_fail.down` back to false. Think this better and less annoying behavior when you're trying to clean up everything quickly.  And it has only been true for a small window of time.
* improve warning message when output not found in case local backend used

## Context

* Commuity Post: [V1.1.0 error when doing plan after clean](https://community.boltops.com/t/v1-1-0-error-when-doing-plan-after-clean/832)
* https://github.com/boltops-tools/terraspace/issues/198

## How to Test

Build a simple terraspace project with 2 stacks where one stack is dependent on the other. Deploy each stack individually. Both should work as long as you take care to deploy them in the right order. Otherwise use `terraspace all`.

## Version Changes

Patch