### PR TITLE
fix all down by building child nodes

### DIFF
--- a/lib/terraspace/all/runner.rb
+++ b/lib/terraspace/all/runner.rb
@@ -68,7 +68,8 @@ module Terraspace::All
     end
 
     def build_stack(name)
-      builder = Terraspace::Builder.new(@options.merge(mod: name, clean: false, quiet: true, include_stacks: :root_only))
+      include_stacks = @command == "down" ? :root_with_children : :root_only
+      builder = Terraspace::Builder.new(@options.merge(mod: name, clean: false, quiet: true, include_stacks: include_stacks))
       builder.build(modules: false)
     end
 

--- a/lib/terraspace/builder.rb
+++ b/lib/terraspace/builder.rb
@@ -6,9 +6,15 @@ module Terraspace
 
     # @include_stacks can be 3 values: root_with_children, none, root_only
     #
+    # terraspace all:
+    #
     #     none: dont build any stacks at all. used by `terraspace all up`
     #     root_only: only build root stack. used by `terraspace all up`
-    #     root_with_children: build all parent stacks as well as the root stack. normal `terraspace up`
+    #     root_with_children: build all children stacks as well as the root stack. normal `terraspace all down`
+    #
+    # terraspace up:
+    #
+    #     root_with_children: build all children stacks as well as the root stack. normal `terraspace up`
     #
     def initialize(options={})
       super

--- a/lib/terraspace/builder/children.rb
+++ b/lib/terraspace/builder/children.rb
@@ -8,19 +8,18 @@ class Terraspace::Builder
     end
 
     def build
-      dependencies = Terraspace::Dependency::Registry.data
       # Find out if current deploy stack contains dependency
-      found = dependencies.find do |parent_child|
+      dependencies = Terraspace::Dependency::Registry.data
+      root = dependencies.find do |parent_child|
         parent, _ = parent_child.split(':')
         parent == @mod.name
       end
-      return unless found
+      return unless root
 
-      # Go down graph children, which are the dependencies to build a queue
-      parent, _ = found.split(':')
-      node = Terraspace::Dependency::Node.find_by(name: parent)
+      # Go down dependency graph to build a queue for processing
+      name, _ = root.split(':')
+      node = Terraspace::Dependency::Node.find_by(name: name)
       build_queue(node)
-
       logger.debug "Terraspace::Builder::Children @queue #{@queue}"
 
       # Process queue in reverse order to build leaf nodes first


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Fix `terraspace all down`. The #196 change in v1.1.0 means only required stacks are build. It works for `terraspace all up`, and then `terraspace all down` would work as long as the `.terraspace-cache` folder still exist. But on a clean machine without `.terraspace-cache`, then `terraspace all down` wouldnt work because the dependent stacks were not built and available for `terraform state pull` to work.

This fixes the issue. Additionally, will be adding a codebuild project with an acceptance test for `terraspace all`.

## Context

* #196
* #199
* https://community.boltops.com/t/terraspace-all-down-not-building-dependent-stacks/848/4

## How to Test

    git clone https://github.com/boltops-tools/terraspace-graph-demo
    cd terraspace-graph-demo
    terraspace all up -y
    terraspace clean all -y
    terraspace all down -y # should work

## Version Changes

Patch