### PR TITLE
hooks.show option

### DIFF
--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -36,33 +36,45 @@ module Terraspace
       config.auto_create_backend = true
       config.autodetect = ActiveSupport::OrderedOptions.new
       config.autodetect.expander = nil
+
       config.build = ActiveSupport::OrderedOptions.new
       config.build.cache_dir = ":CACHE_ROOT/:REGION/:ENV/:BUILD_DIR"
       config.build.cache_root = nil # defaults to /full/path/to/.terraspace-cache
       config.build.clean_cache = nil # defaults to /full/path/to/.terraspace-cache
       config.build.default_pass_files = ["/files/"]
       config.build.pass_files = []
+
       config.bundle = ActiveSupport::OrderedOptions.new
       config.bundle.logger = ts_logger
+
+      config.hooks = ActiveSupport::OrderedOptions.new
+      config.hooks.show = true
+
       config.init = ActiveSupport::OrderedOptions.new
       config.init.mode = "auto" # auto, never, always
+
       config.log = ActiveSupport::OrderedOptions.new
       config.log.root = Terraspace.log_root
       config.logger = ts_logger
       config.logger.formatter = Logger::Formatter.new
       config.logger.level = ENV['TS_LOG_LEVEL'] || :info
+
       config.layering = ActiveSupport::OrderedOptions.new
       config.layering.names = {}
       config.layering.enable_names = ActiveSupport::OrderedOptions.new
       config.layering.enable_names.expansion = true
+
       config.summary = ActiveSupport::OrderedOptions.new
       config.summary.prune = false
+
       config.terraform = ActiveSupport::OrderedOptions.new
       config.terraform.plugin_cache = ActiveSupport::OrderedOptions.new
       config.terraform.plugin_cache.dir = ENV['TF_PLUGIN_CACHE_DIR'] || "#{Terraspace.tmp_root}/plugin_cache"
       config.terraform.plugin_cache.enabled = false
       config.terraform.plugin_cache.purge_on_error = true
+
       config.test_framework = "rspec"
+
       config.tfc = ActiveSupport::OrderedOptions.new
       config.tfc.auto_sync = true
       config.tfc.hostname = nil

--- a/lib/terraspace/cli/init.rb
+++ b/lib/terraspace/cli/init.rb
@@ -65,7 +65,7 @@ class Terraspace::CLI
     end
 
     def auto_init?
-      # terraspace commands not terraform commands. included some extra terraform commands here in case terrapace adds those later
+      # terraspace commands not terraform commands. included some extra terraform commands here in case terraspace adds those later
       commands = %w[all apply console down output plan providers refresh show state up validate]
       commands.include?(calling_command)
     end

--- a/lib/terraspace/ext/core/module.rb
+++ b/lib/terraspace/ext/core/module.rb
@@ -19,7 +19,7 @@ class Module
     full_dir = "#{parent_dir}/#{dir}"
     paths = Dir.glob("#{full_dir}/**/*.rb")
     if paths.empty?
-      raise "Empty include_modules dir: #{dir}"
+      raise "Empty include_modules full_dir: #{full_dir}"
     end
     paths.each do |path|
       regexp = Regexp.new(".*/lib/")

--- a/lib/terraspace/hooks/builder.rb
+++ b/lib/terraspace/hooks/builder.rb
@@ -40,7 +40,7 @@ module Terraspace::Hooks
       command = File.basename(@file).sub('.rb','') # IE: terraform or terraspace
       id = "#{command} #{type} #{@name}"
       label = " label: #{hook["label"]}" if hook["label"]
-      logger.info  "Hook: Running #{id} hook.#{label}".color(:cyan)
+      logger.info  "Hook: Running #{id} hook.#{label}".color(:cyan) if Terraspace.config.hooks.show
       Runner.new(@mod, hook).run
     end
 


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Add `config.hooks.show` option. Prints out the hook label.

## How to Test

Sanity check is fine

## Version Changes

Patch