### PR TITLE
remove duplicate paths in layering

### DIFF
--- a/lib/terraspace/compiler/strategy/tfvar/layer.rb
+++ b/lib/terraspace/compiler/strategy/tfvar/layer.rb
@@ -41,7 +41,7 @@ class Terraspace::Compiler::Strategy::Tfvar
     def paths
       project_paths = full_paths(project_tfvars_dir)
       stack_paths   = full_paths(stack_tfvars_dir)
-      paths = project_paths + stack_paths
+      paths = (project_paths + stack_paths).uniq
       show_layers(paths)
       paths.select do |path|
         File.exist?(path)


### PR DESCRIPTION
This is a 🐞 bug fix. 

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [X] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Removes duplicate entries from layering paths that occur when you add a layer name mapping that matches `TS_ENV`.

Eventually this leads to tfvar files with duplicated variables -  `1-sbx.auto.tfvar` `2-sbx.auto.tfvar`.

## Context

This really extended from my improper use of layer name mappings. It was a simple fix once I tracked it down (in the config), but thought it could warrant a fix anyway to prevent user frustration in the future.

## How to Test

`TS_SHOW_ALL_LAYERS=1` was showing duplicate entries when running `TS_ENV=sbx terraspace build mystack`.  See output below.

```
    ....
    config/terraform/tfvars/base.tfvars
    # this is duplicated below
    config/terraform/tfvars/sbx.tfvars
    config/terraform/tfvars/sbx/base.tfvars
    config/terraform/tfvars/sbx/sbx.tfvars
    config/terraform/tfvars/us-east-1.tfvars
    config/terraform/tfvars/us-east-1/base.tfvars
    config/terraform/tfvars/us-east-1/sbx.tfvars
    config/terraform/tfvars/us-east-1/sbx/base.tfvars
    config/terraform/tfvars/us-east-1/sbx/sbx.tfvars
    # duplication starts here of `sbx`
    config/terraform/tfvars/sbx.tfvars
    config/terraform/tfvars/sbx/base.tfvars
    ...
```

I tracked this back to namespace mappings where I had added to `config/app.rb`, see below. 

```ruby
Terraspace.configure do |config|
  config.layering.names = {
    "123456789123" => "dev",
    "123456789124" => "prd",
    "123456789125" => "stg",  <--- changing this to acct-stg prevents the duplicates
    "123456789126" => "sbx",
  }
end
```

Please feel  free to reject this fix if you feel it is not necessary due to the improper use of mappings.  