### PR TITLE
:PROJECT variable: TS_PROJECT as well as config.cloud.project

### DIFF
--- a/lib/terraspace/core.rb
+++ b/lib/terraspace/core.rb
@@ -18,6 +18,14 @@ module Terraspace
       ENV['TS_EXTRA'] unless ENV['TS_EXTRA'].blank?
     end
 
+    def project
+      if ENV['TS_PROJECT'].blank?
+        config.cloud.project
+      else
+        ENV['TS_PROJECT']
+      end
+    end
+
     @@root = nil
     def root
       @@root ||= ENV['TS_ROOT'] || Dir.pwd

--- a/lib/terraspace/plugin/expander/interface.rb
+++ b/lib/terraspace/plugin/expander/interface.rb
@@ -96,10 +96,11 @@ module Terraspace::Plugin::Expander
       @mod.name
     end
 
-    def app;   Terraspace.app   ; end
-    def role;  Terraspace.role  ; end
-    def env;   Terraspace.env   ; end
-    def extra; Terraspace.extra ; end
+    def app;     Terraspace.app     ; end
+    def env;     Terraspace.env     ; end
+    def extra;   Terraspace.extra   ; end
+    def project; Terraspace.project ; end
+    def role;    Terraspace.role    ; end
 
     def type_instance
       [type, instance].reject { |s| s.blank? }.join('-')
@@ -112,10 +113,6 @@ module Terraspace::Plugin::Expander
 
     def cache_root
       Terraspace.cache_root
-    end
-
-    def project
-      Terraspace.config.cloud.project
     end
 
     # So default config works:


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
This is a 🧐 documentation change.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

The `:PROJECT` variable will use `TS_PROJECT` env var as well as `config.cloud.project` 

* https://terraspace.cloud/docs/cloud/config/
* https://terraspace.cloud/docs/cloud/setup/

## Context

#241 

## How to Test

Sanity test

## Version Changes

Patch