### PR TITLE
rename _cache2 to .cache2

### DIFF
--- a/lib/terraspace/cli/concerns/plan_path.rb
+++ b/lib/terraspace/cli/concerns/plan_path.rb
@@ -2,7 +2,7 @@ module Terraspace::CLI::Concerns
   module PlanPath
     # Use when --out option not used
     def plan_path
-      ".terraspace-cache/_cache2/plan/plan.binary"
+      ".terraspace-cache/.cache2/plan/plan.binary"
     end
   end
 end

--- a/lib/terraspace/cloud/base.rb
+++ b/lib/terraspace/cloud/base.rb
@@ -62,7 +62,7 @@ module Terraspace::Cloud
       # terraform plan can be a kind of apply or destroy
       # terraform apply can be a kind of apply or destroy
       kind = self.class.name.to_s.split('::').last.underscore # IE: apply or destroy
-      dir = "#{@mod.cache_dir}/.terraspace-cache/_cache2/#{kind}"
+      dir = "#{@mod.cache_dir}/.terraspace-cache/.cache2/#{kind}"
       FileUtils.rm_rf(dir)
       FileUtils.mkdir_p(dir)
     end

--- a/lib/terraspace/cloud/folder/base.rb
+++ b/lib/terraspace/cloud/folder/base.rb
@@ -11,7 +11,7 @@ class Terraspace::Cloud::Folder
     end
 
     def artifacts_path
-      "#{@mod.cache_dir}/.terraspace-cache/_cache2/artifacts/#{@type}"
+      "#{@mod.cache_dir}/.terraspace-cache/.cache2/artifacts/#{@type}"
     end
   end
 end

--- a/lib/terraspace/cloud/folder/package.rb
+++ b/lib/terraspace/cloud/folder/package.rb
@@ -12,7 +12,7 @@ class Terraspace::Cloud::Folder
       FileUtils.rm_rf(artifacts_path)
       FileUtils.mkdir_p(File.dirname(artifacts_path))
 
-      expr = "#{@mod.cache_dir}/.terraspace-cache/_cache2/#{@type}/*"
+      expr = "#{@mod.cache_dir}/.terraspace-cache/.cache2/#{@type}/*"
       Dir.glob(expr).each do |src|
         dest = "#{artifacts_path}/#{File.basename(src)}"
         FileUtils.mkdir_p(File.dirname(dest))

--- a/lib/terraspace/cloud/update.rb
+++ b/lib/terraspace/cloud/update.rb
@@ -23,7 +23,7 @@ module Terraspace::Cloud
       clean_cache2_stage
       # .terraspace-cache/dev/stacks/demo
       Dir.chdir(@mod.cache_dir) do
-        cache2_path = ".terraspace-cache/_cache2/#{@kind}"
+        cache2_path = ".terraspace-cache/.cache2/#{@kind}"
         FileUtils.mkdir_p(cache2_path)
 
         IO.write("#{cache2_path}/#{@kind}.log", Terraspace::Logger.logs)

--- a/lib/terraspace/terraform/ihooks/after/plan.rb
+++ b/lib/terraspace/terraform/ihooks/after/plan.rb
@@ -22,7 +22,7 @@ module Terraspace::Terraform::Ihooks::After
     def cloud_create_plan
       return unless Terraspace.cloud?
 
-      unless @mod.out_option.include?("_cache2")
+      unless @mod.out_option.include?(".cache2/")
         # copy absolute path directly
         src = @mod.out_option.starts_with?('/') ? @mod.out_option : "#{@mod.cache_dir}/#{@mod.out_option}"
         dest = "#{@mod.cache_dir}/#{plan_path}"


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Use `.terraspace-cache/.cache2` instead of `.terraspace-cache/_cache2`. The `.cache2` dir is used internally by for Terraspace Cloud. Using a .cache2 gets rid of a slight annoyance when `cd .terraspace-cache` and hitting tab to a build directory for debugging.

## How to Test

Run acceptance test pipeline.

## Version Changes

Patch