### PR TITLE
set utf8 in case system is not configured with LANG=en_US.UTF-8

### DIFF
--- a/lib/terraspace/cli/logs/concern.rb
+++ b/lib/terraspace/cli/logs/concern.rb
@@ -2,7 +2,7 @@ class Terraspace::CLI::Logs
   module Concern
     # Filters for lines that belong to the last ran process pid
     def readlines(path)
-      lines = IO.readlines(path)
+      lines = IO.readlines(path).map { |l| l.force_encoding('UTF-8') }
       found = lines.reverse.find do |line|
         pid(line) # search in reverse order for lines with interesting info
       end

--- a/lib/terraspace/logger.rb
+++ b/lib/terraspace/logger.rb
@@ -45,7 +45,8 @@ module Terraspace
       end
 
       def logs
-        @@buffer.join('')
+        # force_encoding https://jch.github.io/posts/2013-03-05-ruby-incompatible-encoding.html
+        @@buffer.map { |s| s.force_encoding('UTF-8') }.join('')
       end
 
       # for test framework


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Edge case error when special characters from terraform output, 3rd party script output, or system not configure with ` LANG=en_US.UTF-8`, and terraspace errors. 

## How to Test

Run acceptance test pipeline

## Version Changes

Patch