### PR TITLE
fix destroy success return

### DIFF
--- a/lib/terraspace/cli/down.rb
+++ b/lib/terraspace/cli/down.rb
@@ -50,6 +50,7 @@ class Terraspace::CLI
       end
 
       logger.info "Terraspace Cloud #{update['data']['attributes']['url']}" if update
+      success
     end
 
     def cloud_update


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Return the success status at end of destroy properly.

## How to Test

Test `terraspace down demo` with a terraform resource that cannot be deleted successful.

## Version Changes

Patch