### PR TITLE
deprecation warning for :CACHE_ROOT in config.build.cache_dir

### DIFF
--- a/lib/terraspace/mod.rb
+++ b/lib/terraspace/mod.rb
@@ -128,6 +128,27 @@ module Terraspace
           raise "ERROR: config.build.cache_dir is not a String or responds to the .call method."
         end
 
+      if pattern.include?(":CACHE_ROOT")
+        old_pattern = pattern
+        pattern = pattern.sub(':CACHE_ROOT/', '')
+        logger.info "WARN: Detected :CACHE_ROOT in config.build.cache_dir".color(:yellow)
+        logger.info <<~EOL
+          This has been deprecated and :CACHE_ROOT should not be in the config.build.cache_dir setting.
+          The :CACHE_ROOT pattern has been removed from config.build.cache_dir automatically.
+
+          To remove this warning, remove the :CACHE_ROOT. For example:
+
+          config/app.rb
+
+              config.build.cache_dir = "#{old_pattern}"
+
+          Update it to:
+
+              config.build.cache_dir = "#{pattern}"
+
+        EOL
+      end
+
       path = expansion(pattern)
       path = "#{Terraspace.cache_root}/#{path}"
       path.gsub!(%r{/+},'/') # remove double slashes are more. IE: // -> / Useful since region is '' in generic expander


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

For users migrating from v1 to v2, they'll neeed update the terraspace app.rb cache_dir value if they have configured the setting. They will need to remove `:CACHE_ROOT`.

This PR provides a warning message about `:CACHE_ROOT` removal from `config.build.cache_dir` to user.

## Context

https://community.boltops.com/t/migration-from-v1-to-v2-update-the-terraspace-app-rb-cache-dir-value/926/2

## How to Test

Run sanity check

## Version Changes

Patch