### PR TITLE
dont compute git info when not cloud not enabled and warn message improvement

### DIFF
--- a/lib/terraspace/cloud/vcs/commenter.rb
+++ b/lib/terraspace/cloud/vcs/commenter.rb
@@ -46,6 +46,7 @@ class Terraspace::Cloud::Vcs
     # pr_url
     #
     def vcs_vars
+      return {} unless Terraspace.cloud?
       ci_env = CiEnv.new
       local_git = LocalGit.new
       local_env = LocalEnv.new

--- a/lib/terraspace/cloud/vcs/local_git.rb
+++ b/lib/terraspace/cloud/vcs/local_git.rb
@@ -1,7 +1,7 @@
 class Terraspace::Cloud::Vcs
   class LocalGit < Base
     def vars
-      if git_repo? && git_installed?
+      if git_repo? && git_installed? && host
         provider_vars = vcs_class ? vcs_class.new(base_vars, git_url).vars : {}
         base_vars.merge(provider_vars).compact # remove items with nil values
       else
@@ -36,6 +36,15 @@ class Terraspace::Cloud::Vcs
       return nil if git_url.blank?
       uri = URI(git_url)
       "#{uri.scheme}://#{uri.host}"
+    rescue URI::InvalidURIError => e
+      logger.info "WARN: #{e.class} #{e.message}".color(:yellow)
+      logger.info <<~EOL
+        Unable to get the host info from your local .git/config
+        Will not be able to determine local git info.
+        If possible, it would be a useful to provide the remote.url in your .git/config
+        as an issue report or email to improve help improve this logic.
+      EOL
+      nil
     end
 
     def full_repo


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Don't compute vcs info when terraspace cloud is not in use. Also provide a user a warning when unable to get info from local git repo. 

## Context

Closes #254 

## How to Test

Sanity test

## Version Changes

Patch