### PR TITLE
Fix terraform apply/destroy missing some passthrough options

### DIFF
--- a/lib/terraspace/terraform/args/pass.rb
+++ b/lib/terraspace/terraform/args/pass.rb
@@ -60,6 +60,17 @@ module Terraspace::Terraform::Args
       result
     end
 
+    def terraform_arg_types
+      arg_types = terraform_arg_types_for_command(@name)
+      # "terraspace apply/destroy" support the same options as "plan", but they don't document
+      # them directly in their "-help" option, so we need to add them.
+      if ["apply", "destroy"].include? @name
+        arg_types.merge! terraform_arg_types_for_command("plan")
+      end
+
+      arg_types
+    end
+
     # Parses terraform COMMAND -help output for arg types.
     # Return Example:
     #
@@ -69,8 +80,8 @@ module Terraspace::Terraform::Args
     #       var: :hash,
     #     }
     #
-    def terraform_arg_types
-      out = terraform_help(@name)
+    def terraform_arg_types_for_command(name)
+      out = terraform_help(name)
       lines = out.split("\n")
       lines.select! do |line|
         line =~ /^  -/

--- a/spec/terraspace/terraform/args/pass_spec.rb
+++ b/spec/terraspace/terraform/args/pass_spec.rb
@@ -51,6 +51,19 @@ describe Terraspace::Terraform::Args::Pass do
     end
   end
 
+  context "indirectly documented args" do
+    # "terraform apply -help" doesn't document "-target" directly, but refers to
+    # "terraform plan -help" documentation.
+    context "-target=resource" do
+      let(:args) { ["-target=foo.bar"] }
+      let(:name) { "apply" }
+      it "pass through args" do
+        args = pass.args
+        expect(args).to eq ["-target=foo.bar"]
+      end
+    end
+  end
+
   context "hash arg" do
     context "-var 'foo=bar'" do
       let(:args) { ["-var 'foo=bar'"] }


### PR DESCRIPTION

This is a 🐞 bug fix.

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] ~I've adjusted the documentation (if it's a feature or enhancement)~
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Terraform 1.1.0+ unified some options and the help section for
"terraform apply" and "terraform destroy" changed then. See PR:
https://github.com/hashicorp/terraform/pull/28489

As a consequence, "terraform apply -help" doesn't contain all
the options supported by "terraform apply". For instance, it
misses the "-target=resource" option, hence terraspace won't pass
it down to terraform while it should. Same goes for "terraform
destroy".

## Context

Previously reported in #235.

## How to Test

You can test with `terraspace up -target=a.given.resource`
- before the PR: the "target" argument was not passed down to terraform
- after the PR: it is passed (speeds things up)

## Version Changes

Patch.