### PR TITLE
improve graph dependency processing

### DIFF
--- a/lib/terraspace/compiler/erb/render.rb
+++ b/lib/terraspace/compiler/erb/render.rb
@@ -6,7 +6,13 @@ module Terraspace::Compiler::Erb
 
     def build
       context = Context.new(@mod)
-      RenderMePretty.result(@src_path, context: context)
+      if @mod.resolved
+        RenderMePretty.result(@src_path, context: context)
+      else
+        # Replace contents so only the `output` and `depends_on` are evaluated
+        temp_path = Rewrite.new(@src_path).rewrite
+        RenderMePretty.result(temp_path, context: context)
+      end
     end
   end
 end

--- a/lib/terraspace/compiler/erb/rewrite.rb
+++ b/lib/terraspace/compiler/erb/rewrite.rb
@@ -1,0 +1,42 @@
+module Terraspace::Compiler::Erb
+  class Rewrite
+    def initialize(src_path)
+      @src_path = src_path
+    end
+
+    def rewrite
+      input = IO.read(@src_path)
+      output = replace(input)
+      tfvar_path = @src_path.sub(Terraspace.root,'')
+      temp_path = "/tmp/terraspace/rewrite#{tfvar_path}"
+      FileUtils.mkdir_p(File.dirname(temp_path))
+      IO.write(temp_path, output)
+      temp_path
+    end
+
+    # Replace contents so only the `output` and `depends_on` are evaluated
+    def replace(input)
+      lines = input.split("\n").map {|l| l+"\n"} # mimic IO.readlines
+      new_lines = lines.map do |line|
+        new_line(line)
+      end
+      new_lines.join('')
+    end
+
+    def new_line(line)
+      md = line.match(/.*(<% |<%=)/) || line.match(/.*<%$/)
+      if md
+        words = %w[output depends_on] # TODO: consider allowing user customizations
+        # IE: <%= output or <% depends_on
+        regexp = Regexp.new(".*<%.*#{words.join('|')}.*")
+        if line.match(regexp)
+          line # passthrough
+        else
+          line.sub('<%', '<%#') # replace with ERB opening comment
+        end
+      else
+        line # passthrough
+      end
+    end
+  end
+end

--- a/spec/terraspace/compiler/erb/render_spec.rb
+++ b/spec/terraspace/compiler/erb/render_spec.rb
@@ -13,7 +13,7 @@ describe Terraspace::Compiler::Erb::Render do
     it "build" do
       allow(Terraspace::Terraform::RemoteState::Marker::Output).to receive(:stack_names).and_return("b1")
       result = render.build
-      expect(result).to eq "length = (unresolved)"
+      expect(result).to eq "length = (unresolved)\n"
     end
   end
 end

--- a/spec/terraspace/compiler/erb/rewrite_spec.rb
+++ b/spec/terraspace/compiler/erb/rewrite_spec.rb
@@ -1,0 +1,30 @@
+describe Terraspace::Compiler::Erb::Rewrite do
+  let(:rewrite) { described_class.new(src_path) }
+
+  context "has output" do
+    let(:src_path) { fixture("rewrite/dev.tfvars") }
+    it "replace" do
+      input =<<~EOL
+        length = <%= output('b1.length') %>
+        foo = <%= foo %>
+        <% depends_on "b1" %>
+        <%
+        3.times do |i|
+          puts i
+        end
+        %>
+      EOL
+      text = rewrite.replace(input)
+      expect(text).to eq <<~EOL
+        length = <%= output('b1.length') %>
+        foo = <%#= foo %>
+        <% depends_on "b1" %>
+        <%#
+        3.times do |i|
+          puts i
+        end
+        %>
+      EOL
+    end
+  end
+end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

* only evaluate output and depends_on in tfvars on first pass
* replace tfvars so only output and depends_on are evaluated

## Context

Related https://community.boltops.com/t/how-to-create-global-stacks/939/5

## How to Test

Sanity check. Test terraspace all

## Version Changes

Patch