### PR TITLE
custom config.build.dependency_words ability

### DIFF
--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -42,6 +42,7 @@ module Terraspace
       config.build.clean_cache = nil # defaults to true
       config.build.default_pass_files = ["/files/"]
       config.build.pass_files = []
+      config.build.dependency_words = []
 
       config.bundle = ActiveSupport::OrderedOptions.new
       config.bundle.logger = ts_logger

--- a/lib/terraspace/compiler/erb/rewrite.rb
+++ b/lib/terraspace/compiler/erb/rewrite.rb
@@ -26,7 +26,10 @@ module Terraspace::Compiler::Erb
     def new_line(line)
       md = line.match(/.*(<% |<%=)/) || line.match(/.*<%$/)
       if md
-        words = %w[output depends_on] # TODO: consider allowing user customizations
+        words = %w[output depends_on]
+        dependency_words = [Terraspace.config.build.dependency_words].flatten
+        words += dependency_words # custom user words to evaluated in first pass also
+        return line if words.include?('*') # passthrough for special case '*'
         # IE: <%= output or <% depends_on
         regexp = Regexp.new(".*<%.*#{words.join('|')}.*")
         if line.match(regexp)


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Introduce `config.build.dependency_words` config ability. 

## Context

https://community.boltops.com/t/bug-introduced-in-2-2-0/952

## How to Test

Here's some example code that can be use to test it.

config/helpers/custom_helper.rb

```ruby
module Terraspace::Project::CustomHelper
  def list
    [{
      'name' => '1',
      'value' => '1'
    }]
  end
end
```

app/stacks/child/tfvars/dev.tfvars

    <% list.each do |item| -%>
    length<%= item['name'] %> = <%= output("demo.length") %>
    <% end -%>

To test:

    terraspace build child

Should build the tfvars file successfully

    $ cat .terraspace-cache/us-west-2/dev/stacks/child/1-dev.auto.tfvars
     length1 = 3

## Version Changes

Patch
