### PR TITLE
fix expansion for the case of ENV var is not set

### DIFF
--- a/lib/terraspace/plugin/expander/interface.rb
+++ b/lib/terraspace/plugin/expander/interface.rb
@@ -84,7 +84,7 @@ module Terraspace::Plugin::Expander
       elsif !ENV[name].blank?
         return ENV[name]
       else
-        return unexpanded
+        return ''
       end
       if downcase == "namespace" && Terraspace.config.layering.enable_names.expansion
         value = friendly_name(value)

--- a/spec/terraspace/provider/expander/generic_spec.rb
+++ b/spec/terraspace/provider/expander/generic_spec.rb
@@ -3,7 +3,7 @@ describe Terraspace::Plugin::Expander::Generic do
   let(:props) do
     {
       bucket:         "my-bucket",
-      key:            ":env/:build_dir/terraform.tfstate", # variable notation expanded by terraspace
+      key:            ":env/:TEAM/:ENVNOTSET/:build_dir/terraform.tfstate", # variable notation expanded by terraspace
       region:         "us-west-2",
       encrypt:        true,
       dynamodb_table: "terraform_locks"
@@ -15,12 +15,14 @@ describe Terraspace::Plugin::Expander::Generic do
     mod
   end
 
+  before { stub_const('ENV', {'TEAM' => 'backend'}) }
+
   context "default path" do
     it "expand" do
       result = expander.expand(props)
       expect(result).to eq({
         bucket: "my-bucket",
-        key: "dev/stacks/core/terraform.tfstate",
+        key: "dev/backend/stacks/core/terraform.tfstate",
         region: "us-west-2",
         encrypt: true,
         dynamodb_table: "terraform_locks"


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://terraspace.cloud/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

As per docs, with Terraspace v2, any environment variable is also available in the expansion helper. IE: MY_VAR=foo can be use in the expansion(":MY_VAR") method.
This works as expected if MY_VAR is set to some value, but in case environment variable MY_VAR is not set it's returning as it is in non-expanded state like ":MY_VAR"
Now with this fix, it returns empty space if environment variable is not set. Unit test case is also updated.

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

Just run the unit test

rspec spec/terraspace/provider/expander/generic_spec.rb


## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

