### PR TITLE
Speed boast copy modules

### DIFF
--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -43,7 +43,9 @@ module Terraspace
       config.build.default_pass_files = ["/files/"]
       config.build.pass_files = []
       config.build.dependency_words = []
-      config.build.copy_modules = true # speed improvement
+      # copy_modules = nil  # => Will show a warning and default to true
+      # copy_modules = true # => Will be default in next major version
+      config.build.copy_modules = nil # speed improvement
 
       config.bundle = ActiveSupport::OrderedOptions.new
       config.bundle.logger = ts_logger

--- a/lib/terraspace/app.rb
+++ b/lib/terraspace/app.rb
@@ -43,6 +43,7 @@ module Terraspace
       config.build.default_pass_files = ["/files/"]
       config.build.pass_files = []
       config.build.dependency_words = []
+      config.build.copy_modules = true # speed improvement
 
       config.bundle = ActiveSupport::OrderedOptions.new
       config.bundle.logger = ts_logger

--- a/lib/terraspace/builder.rb
+++ b/lib/terraspace/builder.rb
@@ -69,7 +69,7 @@ module Terraspace
       with_each_mod(type_dir) do |mod|
         is_root_module = mod.cache_dir == @mod.cache_dir
         next if is_root_module # handled by build_stacks
-        Compiler::Perform.new(mod).compile
+        Compiler::Perform.new(mod, type_dir: type_dir).compile
       end
     end
 

--- a/lib/terraspace/compiler/perform.rb
+++ b/lib/terraspace/compiler/perform.rb
@@ -3,8 +3,9 @@ module Terraspace::Compiler
     include CommandsConcern
     include Basename
 
-    def initialize(mod)
-      @mod = mod
+    def initialize(mod, options={})
+      # options for type_dir
+      @mod, @options = mod, options
     end
 
     def compile
@@ -60,7 +61,7 @@ module Terraspace::Compiler
     end
 
     def compile_mod_file(src_path)
-      content = Strategy::Mod.new(@mod, src_path).run
+      content = Strategy::Mod.new(@mod, src_path, @options).run
       Writer.new(@mod, src_path: src_path).write(content)
     end
 

--- a/lib/terraspace/compiler/strategy/abstract_base.rb
+++ b/lib/terraspace/compiler/strategy/abstract_base.rb
@@ -1,7 +1,8 @@
 module Terraspace::Compiler::Strategy
   class AbstractBase
-    def initialize(mod, src_path)
-      @mod, @src_path = mod, src_path
+    def initialize(mod, src_path, options={})
+      # options for type_dir
+      @mod, @src_path, @options = mod, src_path, options
     end
   end
 end

--- a/lib/terraspace/compiler/strategy/mod.rb
+++ b/lib/terraspace/compiler/strategy/mod.rb
@@ -7,6 +7,9 @@ module Terraspace::Compiler::Strategy
     end
 
     def strategy_class(path)
+      # Significant speed improvement
+      return Mod::Pass if Terraspace.config.build.copy_modules && @options[:type_dir] == "modules"
+
       ext = File.extname(path).sub('.','')
       return Mod::Pass if ext.empty? # infinite loop without this
       return Mod::Pass if Terraspace.pass_file?(path) or !text_file?(path)

--- a/lib/terraspace/compiler/strategy/mod.rb
+++ b/lib/terraspace/compiler/strategy/mod.rb
@@ -1,5 +1,7 @@
 module Terraspace::Compiler::Strategy
   class Mod < AbstractBase
+    include Terraspace::Util::Logging
+
     def run
       klass = strategy_class(@src_path)
       strategy = klass.new(@mod, @src_path) # IE: Terraspace::Compiler::Strategy::Mod::Rb.new
@@ -8,13 +10,46 @@ module Terraspace::Compiler::Strategy
 
     def strategy_class(path)
       # Significant speed improvement
-      return Mod::Pass if Terraspace.config.build.copy_modules && @options[:type_dir] == "modules"
+      return Mod::Pass if copy_modules?
 
       ext = File.extname(path).sub('.','')
       return Mod::Pass if ext.empty? # infinite loop without this
       return Mod::Pass if Terraspace.pass_file?(path) or !text_file?(path)
       # Fallback to Mod::Tf for all other files. ERB useful for terraform.tfvars
       "Terraspace::Compiler::Strategy::Mod::#{ext.camelize}".constantize rescue Mod::Pass
+    end
+
+    @@copy_modules_warned = false
+    def copy_modules?
+      return false unless @options[:type_dir] == "modules"
+
+      copy_modules = Terraspace.config.build.copy_modules
+      if copy_modules.nil? && @@copy_modules_warned == false
+        logger.info "WARN: config.build.copy_modules is not set. Defaulting to true.".color(:yellow)
+        logger.info <<~EOL
+        The terraspace building behavior is to copy modules from
+        the app/modules folder to the .terraspace-cache for speed.
+        Most do not need app/modules to be compiled.
+        Other files like app/stacks and tfvars files are still compiled.
+        This is a change from previous versions of Terraspace, where
+        all files were compiled.
+
+        You can turn this warning off by setting:
+
+        .terraspace/config.rb
+
+            Terraspace.configure do |config|
+              config.build.copy_modules = true
+            end
+
+        In future Terraspace versions, the default will be true.
+        There will be no warning message, but it will still be configurable.
+        EOL
+        copy_modules = true
+        @@copy_modules_warned = true
+      end
+
+      copy_modules
     end
 
   private


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Speed boast to `terraspace build`.

* Instead of compiling and rendering down ERB for `app/modules` files. It'll straight copy these files. It's a notable speed improvement. 
* Rough numbers: Tested with a module that has about 100 files. Noticed a speed improvement of 8s down to 0.5s.

For this change, terraspace prints a warning message about the change in behavior. In the next major release, the warning will go away and this will be the default behavior. 

To disable warning set the new config explicitly.

.terraspace/config.rb

```ruby
Terraspace.configure do |config|
  config.build.copy_modules = true
end
```

## Context

Community Post: [Running "terraspace up stack" is slow](https://community.boltops.com/t/running-terraspace-up-stack-is-slow/1044)

## How to Test

Sanity check

## Version Changes

Patch
