### PR TITLE
update new project generator config/app.rb config.build.copy_modules

### DIFF
--- a/lib/templates/base/project/config/app.rb
+++ b/lib/templates/base/project/config/app.rb
@@ -2,10 +2,7 @@
 Terraspace.configure do |config|
   # config.logger.level = :info
 
-  # To enable Terraspace Cloud set config.cloud.org
-  # config.cloud.org = "ORG"          # required: replace with your org. only letters, numbers, underscore and dashes allowed
-  # config.cloud.project = "main"     # optional. main is the default project name. only letters, numbers, underscore and dashes allowed
-
-  # Uncomment to enable Cost Estimation. See: http://terraspace.cloud/docs/cloud/cost-estimation/
-  # config.cloud.cost.enabled = true
+  # copy_modules setting introduced 2.2.5 to speed up terraspace build
+  # See: https://terraspace.cloud/docs/config/reference
+  config.build.copy_modules = true
 end


### PR DESCRIPTION
This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Update the `new project` config/app.rb to set `config.build.copy_modules = true` so newly generator projects don't get a warning.

Related: https://github.com/boltops-tools/terraspace/pull/301

## How to Test

Do a sanity check.

## Version Changes

Patch