### PR TITLE
feat: add support for exit code in terraspace fmt command

### DIFF
--- a/lib/terraspace/cli/fmt.rb
+++ b/lib/terraspace/cli/fmt.rb
@@ -3,6 +3,8 @@ class Terraspace::CLI
     include Concerns::SourceDirs
     include Terraspace::Util::Logging
 
+    @@exit_status = 0
+
     def initialize(options={})
       @options = options
       @mod_name = options[:mod]
@@ -11,8 +13,13 @@ class Terraspace::CLI
     def run
       logger.info "Formating terraform files"
       dirs.each do |dir|
-        format(dir)
+        err = format(dir)
+        if err
+          @@exit_status = 1
+        end
       end
+
+      exit(@@exit_status)
     end
 
     def format(dir)

--- a/lib/terraspace/cli/fmt/runner.rb
+++ b/lib/terraspace/cli/fmt/runner.rb
@@ -10,14 +10,18 @@ class Terraspace::CLI::Fmt
 
     def format!
       logger.info @dir.color(:green)
+      err = 0
+
       Dir.chdir(@dir) do
         skip_rename
         begin
-          terraform_fmt
+          err = terraform_fmt
         ensure
           restore_rename
         end
       end
+
+      return err
     end
 
     def skip_rename
@@ -29,15 +33,17 @@ class Terraspace::CLI::Fmt
     end
 
     def terraform_fmt
-      sh "terraform fmt"
+      return sh "terraform fmt"
     end
 
     def sh(command)
       logger.debug("=> #{command}")
       success = system(command)
       return if success
+
       logger.info "WARN: There were some errors running terraform fmt for files in #{@dir}:".color(:yellow)
       logger.info "The errors are shown above"
+      return 1
     end
 
     def restore_rename


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [ ] I've added tests (if it's a bug, feature or enhancement) --> `N/A`
- [ ] I've adjusted the documentation (if it's a feature or enhancement) --> `N/A`
- [X] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

This change add support for `exit 1` return code while running `terraspace fmt` command with errors.

**Note :** I am not a ruby developer, feel free to give me insights to improve the code.

## How to Test

Just test the exit code while running `terraspace fmt` for the following scenarii :
1. The configuration has no error, `terraform fmt` SHOULD return `exit code 0`.
2. The configuration has one or more error, `terraform fmt` SHOULD run until the end and SHOULD return a `exit code 1`.
