### PR TITLE
improve terraspace seed for map(string) variables

### DIFF
--- a/lib/terraspace/seeder/content.rb
+++ b/lib/terraspace/seeder/content.rb
@@ -39,7 +39,9 @@ class Terraspace::Seeder
     end
 
     def escape(type, value)
-      if type&.include?('(') # complex type
+      if type == "map(string)"
+        "{...} # #{type}"
+      elsif type&.include?('(') # complex type
         "[...] # #{type}"
       elsif %w[null any true false].include?(value)
         value # no quotes


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Slight improvement to `terraspace seed` to provide better commented out example of `map(string)` variables.

## Context

Related https://github.com/boltops-tools/terraspace/issues/309

## How to Test

Go through AWS Learn guide.

## Version Changes

Patch