### PR TITLE
cleanup terraspace fmt exit status return

### DIFF
--- a/lib/terraspace/cli/fmt.rb
+++ b/lib/terraspace/cli/fmt.rb
@@ -3,8 +3,6 @@ class Terraspace::CLI
     include Concerns::SourceDirs
     include Terraspace::Util::Logging
 
-    @@exit_status = 0
-
     def initialize(options={})
       @options = options
       @mod_name = options[:mod]
@@ -12,14 +10,11 @@ class Terraspace::CLI
 
     def run
       logger.info "Formating terraform files"
+      exit_status = nil
       dirs.each do |dir|
-        err = format(dir)
-        if err
-          @@exit_status = 1
-        end
+        exit_status = format(dir)
       end
-
-      exit(@@exit_status)
+      exit(exit_status)
     end
 
     def format(dir)

--- a/lib/terraspace/cli/fmt/runner.rb
+++ b/lib/terraspace/cli/fmt/runner.rb
@@ -10,18 +10,17 @@ class Terraspace::CLI::Fmt
 
     def format!
       logger.info @dir.color(:green)
-      err = 0
 
+      exit_status = nil
       Dir.chdir(@dir) do
         skip_rename
         begin
-          err = terraform_fmt
+          exit_status = terraform_fmt
         ensure
           restore_rename
         end
       end
-
-      return err
+      exit_status
     end
 
     def skip_rename
@@ -33,17 +32,17 @@ class Terraspace::CLI::Fmt
     end
 
     def terraform_fmt
-      return sh "terraform fmt"
+      sh "terraform fmt"
     end
 
     def sh(command)
       logger.debug("=> #{command}")
       success = system(command)
-      return if success
-
-      logger.info "WARN: There were some errors running terraform fmt for files in #{@dir}:".color(:yellow)
-      logger.info "The errors are shown above"
-      return 1
+      unless success
+        logger.info "WARN: There were some errors running terraform fmt for files in #{@dir}:".color(:yellow)
+        logger.info "The errors are shown above"
+      end
+      $?.exitstatus
     end
 
     def restore_rename


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Some refactoring/cleanup of #308

## Context

related #308


## How to Test

1. write some malform terraform code and then run `terraspace fmt` and check the exit status, echo $? . It looks like `terraform fmt` returns 2 and terraspace passes that back up to `terraspace fmt`
2. write some good terraform code and then run `terraspace fmt` and check the exit status, echo $?. That returns 0.

## Version Changes

Patch