### PR TITLE
Implement `--noop` for `terraspace fmt`

### DIFF
--- a/lib/terraspace/cli/fmt.rb
+++ b/lib/terraspace/cli/fmt.rb
@@ -10,7 +10,7 @@ class Terraspace::CLI
 
     @@exit_status = 0
     def run
-      logger.info "Formating terraform files"
+      logger.info "Formatting terraform files"
       dirs.each do |dir|
         exit_status = format(dir)
         @@exit_status = exit_status if exit_status != 0
@@ -19,7 +19,7 @@ class Terraspace::CLI
     end
 
     def format(dir)
-      Runner.new(dir).format!
+      Runner.new(dir, @options[:noop]).format!
     end
 
   private

--- a/lib/terraspace/cli/fmt/runner.rb
+++ b/lib/terraspace/cli/fmt/runner.rb
@@ -4,8 +4,9 @@ class Terraspace::CLI::Fmt
     include Terraspace::Util::Logging
     SKIP_PATTERN = /\.skip$/
 
-    def initialize(dir)
+    def initialize(dir, check_only)
       @dir = dir
+      @check_only = check_only
     end
 
     def format!
@@ -32,7 +33,11 @@ class Terraspace::CLI::Fmt
     end
 
     def terraform_fmt
-      sh "terraform fmt"
+      if @check_only
+        sh "terraform fmt -check"
+      else
+        sh "terraform fmt"
+      end
     end
 
     def sh(command)
@@ -40,7 +45,11 @@ class Terraspace::CLI::Fmt
       success = system(command)
       unless success
         logger.info "WARN: There were some errors running terraform fmt for files in #{@dir}:".color(:yellow)
-        logger.info "The errors are shown above"
+        if @check_only
+          logger.info "Files that need formatting and any other errors are shown above"
+        else
+          logger.info "The errors are shown above"
+        end
       end
       $?.exitstatus
     end

--- a/lib/terraspace/cli/help/fmt.md
+++ b/lib/terraspace/cli/help/fmt.md
@@ -24,3 +24,7 @@ Format scoping to module or stack types. In case there's a module and stack with
 Format all, so both modules and stacks:
 
     $ terraspace fmt -t all
+
+Check format of all source files, but don't fix.
+
+    $ terraspace fmt --noop


### PR DESCRIPTION

This is a 🙋‍♂️ feature or enhancement.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement) (**Sorry, couldn't see any existing tests for the cli or fmt**)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

When the `--noop` option is used with `terraspace fmt`, return non-zero if one or more files are needing to be formatted, (but leave the files untouched). Useful feature for CI/CD pipelines.

## Context

The `--noop` option seems to be common to all terraspace cli commands, but not implemented for all of them.  For `fmt` we can use Terraform's `-check` option.

## How to Test

Modify some stack/module tf files such that they have formatting issues.
Run `terraspace fmt --noop` and note the return code and the fact files haven't been updated with the formatting fixes.

## Version Changes

Minor?

