### PR TITLE
adding tainting/untainting as a terraspace command

### DIFF
--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -214,6 +214,12 @@ module Terraspace
       State.new(options.merge(subcommand: subcommand, mod: mod, rest: rest)).run
     end
 
+    desc "taint STACK ADDR", "Mark a resource instance as not fully functional."
+    long_desc Help.text(:taint)
+    def import(mod, addr)
+      Import.new(options.merge(mod: mod, addr: addr)).run
+    end
+
     desc "test", "Run test."
     long_desc Help.text(:test)
     def test
@@ -226,6 +232,12 @@ module Terraspace
     out_option.call
     def output(mod, *args)
       Commander.new("output", options.merge(mod: mod, args: args)).run
+    end
+
+    desc "untaint STACK ADDR", "Remove the 'tainted' state from a resource instance."
+    long_desc Help.text(:untaint)
+    def import(mod, addr)
+      Import.new(options.merge(mod: mod, addr: addr)).run
     end
 
     desc "up STACK", "Deploy infrastructure stack."

--- a/lib/terraspace/cli/help/taint.md
+++ b/lib/terraspace/cli/help/taint.md
@@ -1,0 +1,13 @@
+## Examples
+
+    terraspace taint ec2 aws_instance.my_instance
+
+Example with output:
+
+	$ terraspace taint ec2 aws_instance.my_instance
+	Building .terraspace-cache/us-east-1/dev/stacks/ec2
+	Hook: Running terraspace before build hook.
+	Current directory: .terraspace-cache/us-east-1/dev/stacks/ec2
+	 => terraform taint aws_instance.my_instance
+	Resource instance aws_instance.my_instance has been successfully tainted.
+	Releasing state lock. This may take a few moments...

--- a/lib/terraspace/cli/help/untaint.md
+++ b/lib/terraspace/cli/help/untaint.md
@@ -1,0 +1,13 @@
+## Examples
+
+    terraspace untaint ec2 aws_instance.my_instance
+
+Example with output:
+
+	$ terraspace taint ec2 aws_instance.my_instance
+	Building .terraspace-cache/us-east-1/dev/stacks/ec2
+	Hook: Running terraspace before build hook.
+	Current directory: .terraspace-cache/us-east-1/dev/stacks/ec2
+	 => terraform untaint aws_instance.my_instance
+	Resource instance aws_instance.my_instance has been successfully untainted.
+	Releasing state lock. This may take a few moments...

--- a/lib/terraspace/cli/taint.rb
+++ b/lib/terraspace/cli/taint.rb
@@ -1,0 +1,12 @@
+class Terraspace::CLI
+  class Taint < Base
+    def run
+      commander.run
+    end
+
+    def commander
+      Commander.new("taint", @options)
+    end
+    memoize :commander
+  end
+end

--- a/lib/terraspace/cli/untaint.rb
+++ b/lib/terraspace/cli/untaint.rb
@@ -1,0 +1,12 @@
+class Terraspace::CLI
+  class Untaint < Base
+    def run
+      commander.run
+    end
+
+    def commander
+      Commander.new("untaint", @options)
+    end
+    memoize :commander
+  end
+end

--- a/lib/terraspace/terraform/args/thor.rb
+++ b/lib/terraspace/terraform/args/thor.rb
@@ -121,6 +121,14 @@ module Terraspace::Terraform::Args
       [@options[:addr], @options[:id]]
     end
 
+    def taint_args
+      [@options[:addr]]
+    end
+
+    def untaint_args
+      [@options[:addr]]
+    end
+
     def auto_approve_arg
       @options[:yes] || @options[:auto] ? ["-auto-approve"] : []
     end


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://terraspace.cloud/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Taint and untaint are very useful Terraform commands when you need to force the replacement of a resource. Moving these subcommands as first class citizens for Terraspace reduces overhead in management by no longer requiring a need to shift to the cache directory to drop into the terraform cli to perform such tasks.

This pull request adds them to the Terraspace list of subcommands that can easily be carried out without having to navigate to a cache directory.
<!--
Provide a description of what your pull request changes.
-->

## Context

No context known of

## Version Changes

unknown