### PR TITLE
terraspace fmt: generalize and pass through fmt option

### DIFF
--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -111,8 +111,9 @@ module Terraspace
     desc "fmt", "Run terraform fmt"
     long_desc Help.text(:fmt)
     type_option.call
-    def fmt(mod=nil)
-      Fmt.new(options.merge(mod: mod)).run
+    def fmt(*args)
+      mod = args.shift if args.first && !args.first.include?('-')
+      Fmt.new(options.merge(mod: mod, args: args)).run
     end
 
     desc "import STACK ADDR ID", "Import existing infrastructure into your Terraform state"

--- a/lib/terraspace/cli/fmt.rb
+++ b/lib/terraspace/cli/fmt.rb
@@ -10,7 +10,7 @@ class Terraspace::CLI
 
     @@exit_status = 0
     def run
-      logger.info "Formating terraform files"
+      logger.info "Formatting terraform files"
       dirs.each do |dir|
         exit_status = format(dir)
         @@exit_status = exit_status if exit_status != 0
@@ -19,7 +19,7 @@ class Terraspace::CLI
     end
 
     def format(dir)
-      Runner.new(dir).format!
+      Runner.new(dir, @options).format!
     end
 
   private

--- a/lib/terraspace/cli/help/fmt.md
+++ b/lib/terraspace/cli/help/fmt.md
@@ -24,3 +24,13 @@ Format scoping to module or stack types. In case there's a module and stack with
 Format all, so both modules and stacks:
 
     $ terraspace fmt -t all
+
+Check format of all source files, but don't fix. Examples:
+
+    $ terraspace fmt demo -write=false -list
+    $ terraspace fmt demo -check
+    $ terraspace fmt -write=false -list
+
+## Some Notes
+
+The `terraspace fmt` will only format terraform source files that do not have any ERB templating logic in it. It will format the files directly in your source code. IE: app/stacks/demo


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Pass through args to the fmt command so that these all work

    terraspace fmt demo -check
    terraspace fmt demo -write=false -list
    terraspace fmt -write=false -list

Example with output

    ❯ terraspace fmt -write=false -list
    Formatting terraform files
    app/modules/example
    => terraform fmt -write=false
    app/stacks/demo
    => terraform fmt -write=false
    main.tf

## Context

Related https://github.com/boltops-tools/terraspace/pull/316

## How to Test

Run example commands above

## Version Changes

Patch