### PR TITLE
remove unused noop and verbose options

### DIFF
--- a/lib/terraspace/cli.rb
+++ b/lib/terraspace/cli.rb
@@ -2,9 +2,6 @@ module Terraspace
   class CLI < Command
     include Concern
 
-    class_option :verbose, type: :boolean
-    class_option :noop, type: :boolean
-
     yes_option = Proc.new {
       option :yes, aliases: :y, type: :boolean, desc: "-auto-approve the terraform apply"
     }

--- a/lib/terraspace/terraform/tfc/runs/pruner.rb
+++ b/lib/terraspace/terraform/tfc/runs/pruner.rb
@@ -66,7 +66,7 @@ class Terraspace::Terraform::Tfc::Runs
       action = discardable?(item) ? "Discarded" : "Cancelled"
       p = ItemPresenter.new(item)
       msg = "#{action} #{p.id} #{p.message}" # note id is named run-xxx
-      logger.info("NOOP: #{msg}") && return if @options[:noop]
+      logger.info("NOOP: #{msg}") && return if ENV['NOOP']
 
       if discardable?(item)
         api.runs.discard(id)


### PR DESCRIPTION
This is a 🐞 bug fix.
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Remove the unused `--noop` and `--verbose` global options.

## Context

Related:

* https://github.com/boltops-tools/terraspace/pull/332
* #316

## How to Test

Just sanity check that terraspace still works.

## Version Changes

Patch