### PR TITLE
use tofu fork when available

### DIFF
--- a/lib/terraspace/check.rb
+++ b/lib/terraspace/check.rb
@@ -77,11 +77,10 @@ module Terraspace
       EOL
     end
 
-    # Note opentf is not an official fork yet. Mocked it out for testing.
-    # Should be ready to swap out the official fork name when it is ready.
-    BINS = %w[opentf terraform]
+    BINS = %w[tofu terraform]
     @@terraform_bin = nil
     def terraform_bin
+      return ENV['TS_TERRAFORM_BIN'] if ENV['TS_TERRAFORM_BIN']
       return @@terraform_bin if @@terraform_bin.present?
       BINS.each do |bin|
         if Gem.win_platform?
@@ -115,8 +114,8 @@ module Terraspace
     #
     # Another example
     #
-    #     $ opentf --version
-    #     OpenTF v0.12.24
+    #     $ tofu --version
+    #     OpenTofu v1.6.0
     #
     # Note: The -json option is only available in v0.13+
     def terraform_version


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

The name of the [opentf.org](https://opentofu.org/) fork is `tofu`. Updating terraspace to use it when it's available. 

Users can also override and set with `TS_TERRAFORM_BIN`. Example:

    TS_TERRAFORM_BIN=terraform terraspace up demo
    TS_TERRAFORM_BIN=tofu terraspace up demo

In general though, terraspace will automatically look up a terraform bin. In this order:

1. tofu
2. terraform

## Context

Related: https://opentofu.org/

## How to Test

Install tofu and check that terraspace picks it up.

Examples

    ❯ terraspace check
    terraspace version: 2.2.14
    tofu bin: /usr/bin/tofu
    tofu version: 1.6.0-alpha3
    You're all set!

<details>
 <summary>terraspace up and down</summary>

    ❯ terraspace up demo -y
    Building .terraspace-cache/us-west-2/dev/stacks/demo
    Current directory: .terraspace-cache/us-west-2/dev/stacks/demo
    => tofu init -get -input=false >> /tmp/terraspace/log/init/demo.log
    => tofu plan -input=false

    OpenTofu used the selected providers to generate the following execution
    plan. Resource actions are indicated with the following symbols:
      + create

    OpenTofu will perform the following actions:

      # random_pet.this will be created
      + resource "random_pet" "this" {
          + id        = (known after apply)
          + length    = 2
          + separator = "-"
        }

      # module.bucket.aws_s3_bucket.this will be created
      + resource "aws_s3_bucket" "this" {
          + acceleration_status         = (known after apply)
          + acl                         = (known after apply)
          + arn                         = (known after apply)
          + bucket                      = (known after apply)
          + bucket_domain_name          = (known after apply)
          + bucket_prefix               = (known after apply)
          + bucket_regional_domain_name = (known after apply)
          + force_destroy               = false
          + hosted_zone_id              = (known after apply)
          + id                          = (known after apply)
          + object_lock_enabled         = (known after apply)
          + policy                      = (known after apply)
          + region                      = (known after apply)
          + request_payer               = (known after apply)
          + tags                        = {
              + "Name" = "test1-app-stacks"
            }
          + tags_all                    = {
              + "Name" = "test1-app-stacks"
            }
          + website_domain              = (known after apply)
          + website_endpoint            = (known after apply)
        }

    Plan: 2 to add, 0 to change, 0 to destroy.

    Changes to Outputs:
      + bucket_name = (known after apply)

    ─────────────────────────────────────────────────────────────────────────────

    Note: You didn't use the -out option to save this plan, so OpenTofu can't
    guarantee to take exactly these actions if you run "tofu apply" now.
    => tofu apply -auto-approve -input=false

    OpenTofu used the selected providers to generate the following execution
    plan. Resource actions are indicated with the following symbols:
      + create

    OpenTofu will perform the following actions:

      # random_pet.this will be created
      + resource "random_pet" "this" {
          + id        = (known after apply)
          + length    = 2
          + separator = "-"
        }

      # module.bucket.aws_s3_bucket.this will be created
      + resource "aws_s3_bucket" "this" {
          + acceleration_status         = (known after apply)
          + acl                         = (known after apply)
          + arn                         = (known after apply)
          + bucket                      = (known after apply)
          + bucket_domain_name          = (known after apply)
          + bucket_prefix               = (known after apply)
          + bucket_regional_domain_name = (known after apply)
          + force_destroy               = false
          + hosted_zone_id              = (known after apply)
          + id                          = (known after apply)
          + object_lock_enabled         = (known after apply)
          + policy                      = (known after apply)
          + region                      = (known after apply)
          + request_payer               = (known after apply)
          + tags                        = {
              + "Name" = "test1-app-stacks"
            }
          + tags_all                    = {
              + "Name" = "test1-app-stacks"
            }
          + website_domain              = (known after apply)
          + website_endpoint            = (known after apply)
        }

    Plan: 2 to add, 0 to change, 0 to destroy.

    Changes to Outputs:
      + bucket_name = (known after apply)
    random_pet.this: Creating...
    random_pet.this: Creation complete after 0s [id=logical-moray]
    module.bucket.aws_s3_bucket.this: Creating...
    module.bucket.aws_s3_bucket.this: Creation complete after 1s [id=bucket-logical-moray]

    Apply complete! Resources: 2 added, 0 changed, 0 destroyed.


    Outputs:

    bucket_name = "bucket-logical-moray"
    Time took: 5s

    ❯ terraspace down demo -y
    Building .terraspace-cache/us-west-2/dev/stacks/demo
    Current directory: .terraspace-cache/us-west-2/dev/stacks/demo
    => tofu plan -input=false -destroy
    random_pet.this: Refreshing state... [id=logical-moray]
    module.bucket.aws_s3_bucket.this: Refreshing state... [id=bucket-logical-moray]

    OpenTofu used the selected providers to generate the following execution
    plan. Resource actions are indicated with the following symbols:
      - destroy

    OpenTofu will perform the following actions:
      # random_pet.this will be destroyed
      - resource "random_pet" "this" {
          - id        = "logical-moray" -> null
          - length    = 2 -> null
          - separator = "-" -> null
        }
      # module.bucket.aws_s3_bucket.this will be destroyed
      - resource "aws_s3_bucket" "this" {
          - arn                         = "arn:aws:s3:::bucket-logical-moray" -> null
          - bucket                      = "bucket-logical-moray" -> null
          - bucket_domain_name          = "bucket-logical-moray.s3.amazonaws.com" -> null
          - bucket_regional_domain_name = "bucket-logical-moray.s3.us-west-2.amazonaws.com" -> null
          - force_destroy               = false -> null
          - hosted_zone_id              = "Z3BJ6K6RIION7M" -> null
          - id                          = "bucket-logical-moray" -> null
          - object_lock_enabled         = false -> null
          - region                      = "us-west-2" -> null
          - request_payer               = "BucketOwner" -> null
          - tags                        = {
              - "Name" = "test1-app-stacks"
            } -> null
          - tags_all                    = {
              - "Name" = "test1-app-stacks"
            } -> null

          - grant {
              - id          = "0a1482b6182dbd965b93fc1e091b5d434dad57eb19b5f04ffb6b9e3450677c98" -> null
              - permissions = [
                  - "FULL_CONTROL",
                ] -> null
              - type        = "CanonicalUser" -> null
            }

          - server_side_encryption_configuration {
              - rule {
                  - bucket_key_enabled = false -> null

                  - apply_server_side_encryption_by_default {
                      - sse_algorithm = "AES256" -> null
                    }
                }
            }

          - versioning {
              - enabled    = false -> null
              - mfa_delete = false -> null
            }
        }

    Plan: 0 to add, 0 to change, 2 to destroy.


    Changes to Outputs:
      - bucket_name = "bucket-logical-moray" -> null

    ─────────────────────────────────────────────────────────────────────────────

    Note: You didn't use the -out option to save this plan, so OpenTofu can't
    guarantee to take exactly these actions if you run "tofu apply" now.
    Building .terraspace-cache/us-west-2/dev/stacks/demo
    => tofu destroy -auto-approve
    random_pet.this: Refreshing state... [id=logical-moray]
    module.bucket.aws_s3_bucket.this: Refreshing state... [id=bucket-logical-moray]

    OpenTofu used the selected providers to generate the following execution
    plan. Resource actions are indicated with the following symbols:
      - destroy

    OpenTofu will perform the following actions:

      # random_pet.this will be destroyed
      - resource "random_pet" "this" {
          - id        = "logical-moray" -> null
          - length    = 2 -> null
          - separator = "-" -> null
        }

      # module.bucket.aws_s3_bucket.this will be destroyed
      - resource "aws_s3_bucket" "this" {
          - arn                         = "arn:aws:s3:::bucket-logical-moray" -> null
          - bucket                      = "bucket-logical-moray" -> null
          - bucket_domain_name          = "bucket-logical-moray.s3.amazonaws.com" -> null
          - bucket_regional_domain_name = "bucket-logical-moray.s3.us-west-2.amazonaws.com" -> null
          - force_destroy               = false -> null
          - hosted_zone_id              = "Z3BJ6K6RIION7M" -> null
          - id                          = "bucket-logical-moray" -> null
          - object_lock_enabled         = false -> null
          - region                      = "us-west-2" -> null
          - request_payer               = "BucketOwner" -> null
          - tags                        = {
              - "Name" = "test1-app-stacks"
            } -> null
          - tags_all                    = {
              - "Name" = "test1-app-stacks"
            } -> null

          - grant {
              - id          = "0a1482b6182dbd965b93fc1e091b5d434dad57eb19b5f04ffb6b9e3450677c98" -> null
              - permissions = [
                  - "FULL_CONTROL",
                ] -> null
              - type        = "CanonicalUser" -> null
            }

          - server_side_encryption_configuration {
              - rule {
                  - bucket_key_enabled = false -> null

                  - apply_server_side_encryption_by_default {
                      - sse_algorithm = "AES256" -> null
                    }
                }
            }

          - versioning {
              - enabled    = false -> null
              - mfa_delete = false -> null
            }
        }

    Plan: 0 to add, 0 to change, 2 to destroy.

    Changes to Outputs:
      - bucket_name = "bucket-logical-moray" -> null
    module.bucket.aws_s3_bucket.this: Destroying... [id=bucket-logical-moray]
    module.bucket.aws_s3_bucket.this: Destruction complete after 0s
    random_pet.this: Destroying... [id=logical-moray]
    random_pet.this: Destruction complete after 0s

    Destroy complete! Resources: 2 destroyed.

    Time took: 6s
</details>


## Version Changes

Patch