### PR TITLE
improve tfvars lookup location to include config/stacks/demo/tfvars

### DIFF
--- a/lib/terraspace/compiler/strategy/tfvar/layer.rb
+++ b/lib/terraspace/compiler/strategy/tfvar/layer.rb
@@ -39,9 +39,10 @@ class Terraspace::Compiler::Strategy::Tfvar
     end
 
     def paths
-      project_paths = full_paths(project_tfvars_dir)
-      stack_paths   = full_paths(stack_tfvars_dir)
-      paths = (project_paths + stack_paths).uniq
+      config_terraform = full_paths(config_terraform_tfvars_dir) # deprecated
+      app_stacks = full_paths(app_stacks_tfvars_dir) # deprecated
+      config_stacks = full_paths(config_stacks_tfvars_dir)   # recommended
+      paths = (config_terraform + app_stacks + config_stacks).uniq
       show_layers(paths)
       paths.select do |path|
         File.exist?(path)
@@ -131,27 +132,19 @@ class Terraspace::Compiler::Strategy::Tfvar
       layers
     end
 
-    def project_tfvars_dir
+    # IE: config/terraform/tfvars
+    def config_terraform_tfvars_dir
       "#{Terraspace.root}/config/terraform/tfvars"
     end
 
-    # seed dir takes higher precedence than the tfvars folder within the stack module. Example:
-    #
-    #     seed/tfvars/stacks/demo (folder must have *.tfvars or *.rb files)
-    #     app/stacks/demo/tfvars
-    #
-    # This allows user to take over the tfvars embedded in the stack if they need to. Generally,
-    # putting tfvars in within the app/stacks/MOD/tfvars folder seems cleaner and easier to follow.
-    #
-    # Will also consider app/modules/demo/tfvars. Though modules to be reuseable and stacks is where business logic
-    # should go.
-    #
-    def stack_tfvars_dir
-      seed_dir = "#{Terraspace.root}/seed/tfvars/#{@mod.build_dir(disable_extra: true)}"
-      mod_dir = "#{@mod.root}/tfvars"
+    # IE: app/stacks/demo/tfvars
+    def app_stacks_tfvars_dir
+      "#{@mod.root}/tfvars"
+    end
 
-      empty = Dir.glob("#{seed_dir}/*").empty?
-      empty ? mod_dir : seed_dir
+    # IE: config/stacks/demo/tfvars
+    def config_stacks_tfvars_dir
+      "#{Terraspace.root}/config/#{@mod.build_dir(disable_extra: true)}/tfvars"
     end
 
     @@shown_layers = {}

--- a/lib/terraspace/seeder/where.rb
+++ b/lib/terraspace/seeder/where.rb
@@ -5,30 +5,19 @@ class Terraspace::Seeder
     end
 
     def dest_path
-      case @options[:where]
-      when "app"
-        app_path
-      when "seed"
-        seed_path
+      if @options[:where] == "app"
+        seed_path("app")
       else
-        infer_dest_path
+        seed_path("config")
       end
     end
 
-    def infer_dest_path
-      @mod.type == "stack" ? app_path : seed_path
-    end
-
-    def app_path
-      "#{Terraspace.root}/app/#{@mod.build_dir}/tfvars/#{seed_file}.tfvars"
-    end
-
-    def seed_path
-      "#{Terraspace.root}/seed/tfvars/#{@mod.build_dir}/#{seed_file}.tfvars"
+    def seed_path(folder)
+      "#{Terraspace.root}/#{folder}/#{@mod.build_dir(disable_extra: true)}/tfvars/#{seed_file}.tfvars"
     end
 
     def seed_file
-      @options[:instance] || Terraspace.env
+      [Terraspace.app, Terraspace.role, Terraspace.env, Terraspace.extra].compact.join("/")
     end
   end
 end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->
This is a 🙋‍♂️ feature or enhancement.
<!-- This is a 🧐 documentation change. -->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

Add additional tfvars lookup path at `config/stacks/demo/tfvars`.

    ❯ tree config/stacks
    config/stacks
    └── demo
        └── tfvars
            └── dev.tfvars

Layer is performed in this order:

    config/terraform/tfvars/dev.tfvars
    app/stacks/demo/tfvars/dev.tfvars
    config/stacks/demo/tfvars/dev.tfvars <= NEW

So `config/stacks/demo/tfvars/dev.tfvars` will take the highest precedence and win. 

This allows tfvars config to be decoupled from the stacks. The idea is that stacks can optionally ship with default tfvars files. And uses can completely override them without touching the stack code.

This PR also changes `terraspace seed` so it'll generate the tfvars starter file in `config/stacks/demo/tfvars`

    ❯ terraspace seed demo
    Seeding tfvar files for demo
          create  config/stacks/demo/tfvars/dev.tfvars

Additionally, found this it easier to see what stacks have been deployed by simply running `tree config/stacks`

    ❯ tree config/stacks
    config/stacks
    └── demo
        └── tfvars
            └── dev.tfvars

## How to Test

Just do a sanity check and make sure terraspace works.

## Version Changes

Patch