### PR TITLE
Use Terraspace.tmp_root value instead of hard-coded '/tmp/terraspace'

### DIFF
--- a/lib/terraspace/compiler/erb/rewrite.rb
+++ b/lib/terraspace/compiler/erb/rewrite.rb
@@ -8,7 +8,7 @@ module Terraspace::Compiler::Erb
       input = IO.read(@src_path)
       output = replace(input)
       tfvar_path = @src_path.sub(Terraspace.root,'')
-      temp_path = "/tmp/terraspace/rewrite#{tfvar_path}"
+      temp_path = "#{Terraspace.tmp_root}/rewrite#{tfvar_path}"
       FileUtils.mkdir_p(File.dirname(temp_path))
       IO.write(temp_path, output)
       temp_path

--- a/lib/terraspace/terraform/api/vars/json.rb
+++ b/lib/terraspace/terraform/api/vars/json.rb
@@ -16,7 +16,7 @@ class Terraspace::Terraform::Api::Vars
     rescue JSON::ParserError => e
       # TODO: show exact line with error
       logger.info("ERROR in json: #{e.class}: #{e.message}")
-      path = "/tmp/terraspace/debug/vars.json"
+      path = "#{Terraspace.tmp_root}/terraspace/debug/vars.json"
       logger.info("Result also written to #{path} for inspection")
       FileUtils.mkdir_p(File.dirname(path))
       IO.write(path, result)


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://terraspace.cloud/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

<!--
Provide a description of what your pull request changes.
-->

Use Terraspace.tmp_root value instead of hard-coded '/tmp/terraspace'.

## Context

This resolves the problems I reported here: https://github.com/boltops-tools/terraspace/issues/123#issuecomment-1844317930

Terraspace.tmp_root was not being used consistently throughout the terraspace library source.

Which are sub-problems of existing reported issue: #123 

## How to Test

<!--
Please provide instructions on how to test the fix. This speeds up reviewing the PR. If testing requires a demo Terraspace project, please provide an example repo.
-->

To test, simply run:

`export TS_TMP_ROOT=$HOME/test-foo/ts-tmp`

Then, run `terraspace up <stack>` and you should notice all relevant files will be written under the directory specified by the TS_TMP_ROOT environment variable.

Previously, some files would have been written under the directory defined by TS_TMP_ROOT and some would have been written under '/tmp/terraspace' which was not expected, consistent behavior. 


