### PR TITLE
Update to use terraform_bin for state pull and help

### DIFF
--- a/lib/terraspace/terraform/args/pass.rb
+++ b/lib/terraspace/terraform/args/pass.rb
@@ -114,7 +114,7 @@ module Terraspace::Terraform::Args
 
     @@terraform_help = {}
     def terraform_help(name)
-      @@terraform_help[name] ||= `terraform #{name} -help`
+      @@terraform_help[name] ||= `#{Terraspace.terraform_bin} #{name} -help`
     end
   end
 end

--- a/lib/terraspace/terraform/remote_state/fetcher.rb
+++ b/lib/terraspace/terraform/remote_state/fetcher.rb
@@ -71,7 +71,7 @@ module Terraspace::Terraform::RemoteState
       return unless success
 
       FileUtils.mkdir_p(File.dirname(state_path))
-      command = "cd #{@child.cache_dir} && terraform state pull > #{state_path}"
+      command = "cd #{@child.cache_dir} && #{Terraspace.terraform_bin} state pull > #{state_path}"
       logger.debug "=> #{command}"
       success = system(command)
       # Can error if using a old terraform version and the statefile was created with a newer version of terraform


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://terraspace.cloud/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [X] The test suite passes (run `bundle exec rspec` to verify this)

I don't believe new tests are required since this only touches old code covered by existing tests. 

## Summary

Finds lingering hard references to `terraform` and replaces it with the found binary (which accommodates both `terraform` or `tofu`) 


## Context
This resolves #338 and #344. 

## How to Test

Any dummy terraspace project can be used to test - run against master with `tofu` and a project that uses -no-color and/or has outputs between stacks and do the same with `terraform`.  Then try the same tests with my changes.  

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

