### PR TITLE
fixing typo in untaint help file

### DIFF
--- a/lib/terraspace/cli/help/untaint.md
+++ b/lib/terraspace/cli/help/untaint.md
@@ -4,7 +4,7 @@
 
 Example with output:
 
-	$ terraspace taint ec2 aws_instance.my_instance
+	$ terraspace untaint ec2 aws_instance.my_instance
 	Building .terraspace-cache/us-east-1/dev/stacks/ec2
 	Hook: Running terraspace before build hook.
 	Current directory: .terraspace-cache/us-east-1/dev/stacks/ec2


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://terraspace.cloud/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

<!-- This is a 🐞 bug fix. -->
<!-- This is a 🙋‍♂️ feature or enhancement. -->
This is a 🧐 documentation change.

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ x ] I've added tests (if it's a bug, feature or enhancement)
- [ x ] I've adjusted the documentation (if it's a feature or enhancement)
- [ x ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary
This is merely a documentation typo fix.

## Context
A help file is utilizing the wrong command in its example input, and was originally my mistake.

## How to Test
No testing necessary


