### PR TITLE
Allow up to terraform `1.5.7`

### DIFF
--- a/lib/terraspace/check.rb
+++ b/lib/terraspace/check.rb
@@ -7,7 +7,7 @@ module Terraspace
       @options = options
       # Terraspace requires this terraform version or a fork
       @min_terraform_version = "0.12"
-      @max_terraform_version = "1.5.5"
+      @max_terraform_version = "1.5.7"
     end
 
     # Used for the CLI


### PR DESCRIPTION
`1.5.6` and `1.5.7` were still released under a free and opensource license.

See https://github.com/hashicorp/terraform/blob/v1.5.7/LICENSE