### PR TITLE
Add checks around plugin_gem_name in project Gemfile template

### DIFF
--- a/lib/templates/base/project/Gemfile.tt
+++ b/lib/templates/base/project/Gemfile.tt
@@ -1,7 +1,9 @@
 source "https://rubygems.org"
 
 gem "terraspace", "~> <%= terraspace_minor_version %>"
+<% if plugin_gem_name -%>
 gem "<%= plugin_gem_name %>"
+<% end -%>
 gem "rspec-terraspace"
 
 # Uncomment the ci and vcs provider you wish to use. Should use both ci and vcs gem


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://terraspace.cloud/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary
When creating a project with no plugin (i.e. using `terraspace new project --plugin none infra`) the Gemfile for the project contains a line with no name for the gem which makes it unparsable and stops the build process.

This PR wraps the plugin line with ERB `if/end` statements to avoid inserting the line if there is no plugin or if it wasn't found on the system.

## Context



## How to Test

Run `terraspace new project --plugin none infra` and check that infra/Gemfile doesn't contain a line with just `gem `
I couldn't build a local version to test this myself before creating this PR.
But I'll happily include a testcase to check the fix with some guidance as I haven't written a lot of Ruby.

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

