### PR TITLE
feat: add support for exit code in terraspace validate command

### DIFF
--- a/lib/terraspace/cli/commander.rb
+++ b/lib/terraspace/cli/commander.rb
@@ -9,7 +9,8 @@ class Terraspace::CLI
       Terraspace::Builder.new(@options).run unless @options[:build] # Up already ran build
       Init.new(@options).run
       @runner = Terraspace::Terraform::Runner.new(@name, @options)
-      @runner.run
+      success = @runner.run
+      exit 1 unless success
     end
   end
 end


### PR DESCRIPTION
This is a 🙋‍♂️ feature or enhancement.

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [x ] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

`terraform validate` sets exit code 1 on failed validation, e.g.:

> Error: Reference to undeclared input variable

```
$ echo $?
1
```

But terraspace not:

```
$ terraspace validate epi_cluster
=> terraform validate

│ Error: Reference to undeclared input variable

$ echo $?
0
```

## Context

<!--
Is this related to any GitHub issue(s) or another relevant link?
-->

## How to Test

1. Create a project
2. Break Terraform code, for example by making a typo in a variable name
3. Run `terraspace validate <stack>`
4. Run `echo $?` to check exit code
5. Add to `config/app.rb`:
```
Terraspace.configure do |config|
  config.all.exit_on_fail.validate = true
end
```
6. Run `terraspace all validate`
7. Run `echo $?` to check exit code

## Version Changes

<!--
Which semantic version change would you recommend?
If you don't know, feel free to omit it.
-->

