### PR TITLE
RFC: Support `json` format with `graph` command

### DIFF
--- a/lib/terraspace/all/grapher.rb
+++ b/lib/terraspace/all/grapher.rb
@@ -12,6 +12,10 @@ module Terraspace::All
       graph = build_graph
       if @options[:format] == "text"
         text(graph.top_nodes)
+      elsif @options[:format] == "json"
+        puts (graph.build.map do |batch|
+          batch.map { |stack| stack.name }
+        end).to_json
       else
         draw(graph.nodes)
       end
@@ -117,7 +121,7 @@ module Terraspace::All
 
     # Check if Graphiz is installed and prints a user friendly message if it is not installed.
     def check_graphviz!
-      return if @options[:format] == 'text'
+      return if ['text', 'json'].include?(@options[:format])
 
       installed = system("type dot > /dev/null 2>&1") # dot is a command that is part of the graphviz package
       return if installed


### PR DESCRIPTION
Being able to output the graph in a machine readable format is useful for CI pipelines.  For example, I'm using this to dynamically generate a Gitlab pipeline where stacks are deployed with multiple parallel jobs.

Sample output of `terraspace all graph --format=json`

```json
[["logging","roles","s3_buckets","vpc"],["route53"],["app1","app2"],["app3"]]
```

This is a 🙋‍♂️ feature or enhancement.

Let me know what you think.  If the code itself looks suitable for inclusion, I can have a go at updating any relevant docs and tests etc.
