### PR TITLE
Fix state file fetching race condition

### DIFF
--- a/lib/terraspace/all/runner.rb
+++ b/lib/terraspace/all/runner.rb
@@ -29,6 +29,7 @@ module Terraspace::All
 
     def deploy_batches
       truncate_logs if ENV['TS_TRUNCATE_LOGS']
+      remove_remote_state_cache
       build_modules
       @batches.each_with_index do |batch,i|
         logger.info "Batch Run #{i+1}:"
@@ -55,6 +56,13 @@ module Terraspace::All
       wait_for_child_proccess
       summarize     # also reports lower-level error info
       report_errors # reports finall errors and possibly exit
+    end
+
+    def remove_remote_state_cache
+      remote_state_dir = "#{Terraspace.tmp_root}/remote_state"
+
+      logger.debug "Removing #{remote_state_dir}"
+      FileUtils.rm_rf(remote_state_dir)
     end
 
     def deploy_stack(node)

--- a/lib/terraspace/terraform/remote_state/fetcher.rb
+++ b/lib/terraspace/terraform/remote_state/fetcher.rb
@@ -126,7 +126,7 @@ module Terraspace::Terraform::RemoteState
     end
 
     def state_path
-      "#{Terraspace.tmp_root}/remote_state/#{@child.build_dir}/state.json"
+      "#{Terraspace.tmp_root}/remote_state/#{Process.pid}/#{@child.build_dir}/state.json"
     end
 
     # Note we already validate mod exist at the terraform_output helper. This is just in case that logic changes.


### PR DESCRIPTION
When doing a `terraspace all plan` or `terraspace all up` if multiple stacks being deployed in a batch all depend on the same stack's outputs, there is a race condition where one process tries to read the outputs from a state file it has just pulled, but a second process has meanwhile clobbered the same file.

Instead of trying to implement a fancy solution involving cross process locking, the simplest solution is just to use different filenames for each process by embedding the Process ID into the state file name.

In the case where `concurrency == 1`, the caching in `Terraspace::Terraform::RemoteState::Fetcher.pull` of `pull_successes` will still work as the PID won't change between invocations.

Where `concurrency > 1`, the caching of outputs and pulls was never shared between processes anyway and new state files were always fetched.

To prevent a large build up of potentially large state files, they are always removed at the start of `deploy_batches`.

Fixes #330

