### PR TITLE
Fix 'new project' command for Ruby 3.4.x versions

### DIFF
--- a/lib/terraspace/command.rb
+++ b/lib/terraspace/command.rb
@@ -125,7 +125,7 @@ module Terraspace
       end
 
       def subcommand?
-        !!caller.detect { |l| l.include?('in subcommand') }
+        !!caller.detect { |l| l.match?('in .*subcommand') }
       end
 
       # Override command_help to include the description at the top of the


### PR DESCRIPTION
As discussed in issue #363, the `terraspace new project` command was not working with ruby >= 3.4.X. The main issue being the way line tracing is done in the call stack in the Terraspace::Command#subcommand? method.

For Ruby 3.3.x the code is looking for "in subcommand" substring and matching on this line:

  e.g., "thor.rb:338:in `block in subcommand'"

However for Ruby 3.4.x this line is now:

  e.g., "thor.rb:338:in 'block in Terraspace::CLI#subcommand'"

The fix here is to use l.match? and a regex instead of l.include? to match both of these lines from either Ruby version.

<!--
Thanks for creating a Pull Request! Before you submit, please make sure you've done the following:

- I read the contributing document at https://terraspace.cloud/docs/contributing/
-->

<!--
Make our lives easier! Choose one of the following by uncommenting it:
-->

This is a 🐞 bug fix.
<!-- This is a 🙋‍♂️ feature or enhancement. -->
<!-- This is a 🧐 documentation change. -->

<!--
Before you submit this pull request, make sure to have a look at the following checklist. To mark a checkbox done, replace [ ] with [x]. Or after you create the issue you can click the checkbox.

If you don't know how to do some of these, that's fine!  Submit your pull request and we will help you out on the way.
-->

- [ ] I've added tests (if it's a bug, feature or enhancement)
- [ ] I've adjusted the documentation (if it's a feature or enhancement)
- [ X] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

The `new project` command  with examples was failing for Ruby >= 3.4.x.

## Context

See issue #363.

## How to Test

Install a ruby version >= 3.4.x , use that version, and then try to create a new project, probably with examples as outlined in the documentation (or any other documentation getting started invocation):

```
terraspace new project infra --plugin aws --examples
```


## Version Changes

Bug fix version bump? Patch version increment of sorts probably.

