### PR TITLE
Fix/fmt tfvars

### DIFF
--- a/lib/terraspace/cli/fmt/runner.rb
+++ b/lib/terraspace/cli/fmt/runner.rb
@@ -72,7 +72,7 @@ class Terraspace::CLI::Fmt
     end
 
     def tf_files
-      Dir.glob("#{Terraspace.root}/#{@dir}/**/*.{tf,skip}").select { |p| File.file?(p) }
+      Dir.glob("#{Terraspace.root}/#{@dir}/**/*.{tf,tfvars,skip}").select { |p| File.file?(p) }
     end
   end
 end

--- a/lib/terraspace/cli/help/fmt.md
+++ b/lib/terraspace/cli/help/fmt.md
@@ -31,6 +31,11 @@ Check format of all source files, but don't fix. Examples:
     $ terraspace fmt demo -check
     $ terraspace fmt -write=false -list
 
+Recursively format files in subfolders. The `-recursive` option is passed through to `terraform fmt`:
+
+    $ terraspace fmt -recursive
+    $ terraspace fmt demo -recursive
+
 ## Some Notes
 
 The `terraspace fmt` will only format terraform source files that do not have any ERB templating logic in it. It will format the files directly in your source code. IE: app/stacks/demo

--- a/spec/terraspace/cli/fmt/runner_spec.rb
+++ b/spec/terraspace/cli/fmt/runner_spec.rb
@@ -1,0 +1,55 @@
+require "tmpdir"
+
+describe Terraspace::CLI::Fmt::Runner do
+  let(:dir)    { "app/stacks/demo" }
+  let(:runner) { described_class.new(dir, {}) }
+
+  around(:each) do |example|
+    Dir.mktmpdir do |root|
+      base = "#{root}/#{dir}/tfvars"
+      FileUtils.mkdir_p(base)
+      File.write("#{root}/#{dir}/main.tf", "foo = 1\n")          # plain tf
+      File.write("#{root}/#{dir}/erb.tf",  "foo = <%= 1 %>\n")   # erb tf
+      File.write("#{base}/plain.tfvars",   "foo = 1\n")          # plain tfvars
+      File.write("#{base}/erb.tfvars",     "foo = <%= 1 %>\n")   # erb tfvars
+
+      saved, Terraspace.root = Terraspace.root, root
+      example.run
+      Terraspace.root = saved
+    end
+  end
+
+  def exist?(path)
+    File.exist?("#{Terraspace.root}/#{dir}/#{path}")
+  end
+
+  it "includes tfvars files alongside tf files" do
+    names = runner.send(:tf_files).map { |p| File.basename(p) }
+    expect(names).to include("main.tf", "erb.tf", "plain.tfvars", "erb.tfvars")
+  end
+
+  # Regression: terraform fmt -recursive descends into the tfvars subfolder and
+  # errors on ERB tfvars. They must be renamed out of the way like ERB tf files.
+  it "renames only ERB files (including ERB tfvars) to .skip" do
+    runner.rename_to_skip_fmt
+
+    expect(exist?("erb.tf.skip")).to be true
+    expect(exist?("tfvars/erb.tfvars.skip")).to be true
+    expect(exist?("erb.tf")).to be false
+    expect(exist?("tfvars/erb.tfvars")).to be false
+
+    # non-ERB files are left untouched for terraform fmt to format
+    expect(exist?("main.tf")).to be true
+    expect(exist?("tfvars/plain.tfvars")).to be true
+  end
+
+  it "restores skipped ERB tfvars back to their original name" do
+    runner.rename_to_skip_fmt
+    runner.restore_rename
+
+    expect(exist?("tfvars/erb.tfvars")).to be true
+    expect(exist?("tfvars/erb.tfvars.skip")).to be false
+    expect(exist?("erb.tf")).to be true
+    expect(exist?("erb.tf.skip")).to be false
+  end
+end


### PR DESCRIPTION
<!-- This is a 🐞 bug fix. -->

- [x] I've added tests (if it's a bug, feature or enhancement)
- [x] I've adjusted the documentation (if it's a feature or enhancement)
- [x] The test suite passes (run `bundle exec rspec` to verify this)

## Summary

`terraspace fmt` renames source files containing ERB (`<%`) to `*.skip` before running `terraform fmt`, then restores them. The skip glob only matched `*.{tf,skip}`, so ERB `.tfvars` files were missed. With `-recursive`, `terraform fmt` descends into the `tfvars/` subfolder and errors on them:

Error: Invalid character  on tfvars/base.tfvars line 1:
   1: some_var = <%= output('other-stack.x') %>

Fix: add `tfvars` to the glob so ERB `.tfvars` files are skipped like ERB `.tf` files. Also documents the `-recursive` option in the `fmt` help text.

## Context

`terraform fmt` is non-recursive by default, so `.tfvars` in `tfvars/` are only reached with `-recursive`, where the missing skip handling surfaced as a hard error. One-line change in `lib/terraspace/cli/fmt/runner.rb`:

```diff
- **/*.{tf,skip}
+ **/*.{tf,tfvars,skip}
```

## How to Test

With an ERB .tfvars in a stack's tfvars/ subfolder, terraspace fmt -recursive errors before this change (exit 2) and succeeds after (exit 0, ERB tfvars left intact). Specs:

bundle exec rspec spec/terraspace/cli/fmt/runner_spec.rb

## Version Changes

Patch — backwards-compatible bug fix.